### PR TITLE
Exclude realm-specific clients from client checks

### DIFF
--- a/kcwarden/auditors/client/client_authentication_via_mtls_or_jwt_recommended.py
+++ b/kcwarden/auditors/client/client_authentication_via_mtls_or_jwt_recommended.py
@@ -12,7 +12,10 @@ class ClientAuthenticationViaMTLSOrJWTRecommended(Auditor):
         # We are interested in clients that are:
         # - OIDC Clients
         # - Confidential Clients
-        return self.is_not_ignored(client) and client.is_oidc_client() and not client.is_public()
+        return (self.is_not_ignored(client) 
+                and not client.is_realm_specific_client() 
+                and client.is_oidc_client() 
+                and not client.is_public())
 
     def client_does_not_use_mtls_or_jwt_auth(self, client) -> bool:
         # If the clientAuthenticatorType is client-secret, basic client secret authentication is used.

--- a/kcwarden/auditors/client/client_authentication_via_mtls_or_jwt_recommended.py
+++ b/kcwarden/auditors/client/client_authentication_via_mtls_or_jwt_recommended.py
@@ -12,10 +12,12 @@ class ClientAuthenticationViaMTLSOrJWTRecommended(Auditor):
         # We are interested in clients that are:
         # - OIDC Clients
         # - Confidential Clients
-        return (self.is_not_ignored(client) 
-                and not client.is_realm_specific_client() 
-                and client.is_oidc_client() 
-                and not client.is_public())
+        return (
+            self.is_not_ignored(client)
+            and not client.is_realm_specific_client()
+            and client.is_oidc_client()
+            and not client.is_public()
+        )
 
     def client_does_not_use_mtls_or_jwt_auth(self, client) -> bool:
         # If the clientAuthenticatorType is client-secret, basic client secret authentication is used.

--- a/kcwarden/auditors/client/client_has_erroneously_configured_wildcard_uri.py
+++ b/kcwarden/auditors/client/client_has_erroneously_configured_wildcard_uri.py
@@ -16,6 +16,7 @@ class ClientHasErroneouslyConfiguredWildcardURI(Auditor):
         # - At least one flow that uses the redirect_uri active
         return (
             self.is_not_ignored(client)
+            and not client.is_realm_specific_client()
             and client.is_oidc_client()
             and (client.has_standard_flow_enabled() or client.has_implicit_flow_enabled())
         )

--- a/kcwarden/auditors/client/client_has_undefined_base_domain_and_schema.py
+++ b/kcwarden/auditors/client/client_has_undefined_base_domain_and_schema.py
@@ -17,6 +17,7 @@ class ClientHasUndefinedBaseDomainAndSchema(Auditor):
         # TODO Are there more flows that use redirect_uri?
         return (
             self.is_not_ignored(client)
+            and not client.is_realm_specific_client()
             and client.is_oidc_client()
             and (client.has_standard_flow_enabled() or client.has_implicit_flow_enabled())
         )

--- a/kcwarden/auditors/client/client_must_not_use_unencrypted_nonlocal_redirect_uri.py
+++ b/kcwarden/auditors/client/client_must_not_use_unencrypted_nonlocal_redirect_uri.py
@@ -17,6 +17,7 @@ class ClientMustNotUseUnencryptedNonlocalRedirectUri(Auditor):
         # TODO Are there more flows that use redirect_uri?
         return (
             self.is_not_ignored(client)
+            and not client.is_realm_specific_client()
             and client.is_oidc_client()
             and (client.has_standard_flow_enabled() or client.has_implicit_flow_enabled())
         )

--- a/kcwarden/auditors/client/client_should_disable_implicit_grant_flow.py
+++ b/kcwarden/auditors/client/client_should_disable_implicit_grant_flow.py
@@ -11,7 +11,7 @@ class ClientShouldDisableImplicitGrantFlow(Auditor):
     def should_consider_client(self, client) -> bool:
         # We are interested in clients that are:
         # - OIDC Clients
-        return self.is_not_ignored(client) and client.is_oidc_client()
+        return self.is_not_ignored(client) and client.is_oidc_client() and not client.is_realm_specific_client()
 
     def client_uses_implicit_grant_flow(self, client) -> bool:
         # All clients that have implicit flow enabled are considered suspect

--- a/kcwarden/auditors/client/client_should_not_use_wildcard_redirect_uri.py
+++ b/kcwarden/auditors/client/client_should_not_use_wildcard_redirect_uri.py
@@ -15,6 +15,7 @@ class ClientShouldNotUseWildcardRedirectURI(Auditor):
         # TODO Are there more flows that use redirect_uri?
         return (
             self.is_not_ignored(client)
+            and not client.is_realm_specific_client()
             and client.is_oidc_client()
             and (client.has_standard_flow_enabled() or client.has_implicit_flow_enabled())
         )

--- a/kcwarden/auditors/client/client_uses_custom_redirect_uri_scheme.py
+++ b/kcwarden/auditors/client/client_uses_custom_redirect_uri_scheme.py
@@ -17,6 +17,7 @@ class ClientUsesCustomRedirectUriScheme(Auditor):
         # TODO Are there more flows that use redirect_uri?
         return (
             self.is_not_ignored(client)
+            and not client.is_realm_specific_client()
             and client.is_oidc_client()
             and (client.has_standard_flow_enabled() or client.has_implicit_flow_enabled())
         )

--- a/kcwarden/auditors/client/client_with_default_offline_access_scope.py
+++ b/kcwarden/auditors/client/client_with_default_offline_access_scope.py
@@ -12,7 +12,7 @@ class ClientWithDefaultOfflineAccessScope(Auditor):
     REFERENCE = ""
 
     def should_consider_client(self, client) -> bool:
-        return self.is_not_ignored(client)
+        return self.is_not_ignored(client) and not client.is_realm_specific_client()
 
     def client_can_generate_offline_tokens(self, client) -> bool:
         # Check if the "offline_access" scope is in the default scopes

--- a/kcwarden/auditors/client/client_with_full_scope_allowed.py
+++ b/kcwarden/auditors/client/client_with_full_scope_allowed.py
@@ -9,7 +9,7 @@ class ClientWithFullScopeAllowed(Auditor):
     REFERENCE = ""
 
     def should_consider_client(self, client) -> bool:
-        return self.is_not_ignored(client) and client.allows_user_authentication()
+        return self.is_not_ignored(client) and client.allows_user_authentication() and not client.is_realm_specific_client()
 
     def client_has_full_scope_allowed(self, client) -> bool:
         return client.has_full_scope_allowed()

--- a/kcwarden/auditors/client/client_with_full_scope_allowed.py
+++ b/kcwarden/auditors/client/client_with_full_scope_allowed.py
@@ -9,7 +9,11 @@ class ClientWithFullScopeAllowed(Auditor):
     REFERENCE = ""
 
     def should_consider_client(self, client) -> bool:
-        return self.is_not_ignored(client) and client.allows_user_authentication() and not client.is_realm_specific_client()
+        return (
+            self.is_not_ignored(client)
+            and client.allows_user_authentication()
+            and not client.is_realm_specific_client()
+        )
 
     def client_has_full_scope_allowed(self, client) -> bool:
         return client.has_full_scope_allowed()

--- a/kcwarden/auditors/client/client_with_optional_offline_access_scope.py
+++ b/kcwarden/auditors/client/client_with_optional_offline_access_scope.py
@@ -9,7 +9,7 @@ class ClientWithOptionalOfflineAccessScope(Auditor):
     REFERENCE = ""
 
     def should_consider_client(self, client) -> bool:
-        return self.is_not_ignored(client)
+        return self.is_not_ignored(client) and not client.is_realm_specific_client()
 
     def client_can_generate_offline_tokens(self, client) -> bool:
         # Check if the "offline_access" scope is in the optional scopes

--- a/kcwarden/auditors/client/client_with_service_account_and_other_flow_enabled.py
+++ b/kcwarden/auditors/client/client_with_service_account_and_other_flow_enabled.py
@@ -15,6 +15,7 @@ class ClientWithServiceAccountAndOtherFlowEnabled(Auditor):
         # - Has service account
         return (
             self.is_not_ignored(client)
+            and not client.is_realm_specific_client()
             and client.is_oidc_client()
             and (not client.is_public())
             and client.has_service_account_enabled()

--- a/kcwarden/auditors/client/confidential_client_should_disable_direct_access_grants.py
+++ b/kcwarden/auditors/client/confidential_client_should_disable_direct_access_grants.py
@@ -12,7 +12,11 @@ class ConfidentialClientShouldDisableDirectAccessGrants(Auditor):
         # We are interested in clients that are:
         # - OIDC clients
         # - Are confidential clients
-        return self.is_not_ignored(client) and client.is_oidc_client() and not client.is_public()
+        return (self.is_not_ignored(client) 
+                and not client.is_realm_specific_client()
+                and client.is_oidc_client() 
+                and not client.is_public()
+        )
 
     def client_uses_direct_access_grants(self, client) -> bool:
         # All clients with direct access grants should be reported

--- a/kcwarden/auditors/client/confidential_client_should_disable_direct_access_grants.py
+++ b/kcwarden/auditors/client/confidential_client_should_disable_direct_access_grants.py
@@ -12,10 +12,11 @@ class ConfidentialClientShouldDisableDirectAccessGrants(Auditor):
         # We are interested in clients that are:
         # - OIDC clients
         # - Are confidential clients
-        return (self.is_not_ignored(client) 
-                and not client.is_realm_specific_client()
-                and client.is_oidc_client() 
-                and not client.is_public()
+        return (
+            self.is_not_ignored(client)
+            and not client.is_realm_specific_client()
+            and client.is_oidc_client()
+            and not client.is_public()
         )
 
     def client_uses_direct_access_grants(self, client) -> bool:

--- a/kcwarden/auditors/client/confidential_client_should_enforce_pkce.py
+++ b/kcwarden/auditors/client/confidential_client_should_enforce_pkce.py
@@ -16,6 +16,7 @@ class ConfidentialClientShouldEnforcePKCE(Auditor):
         return (
             self.is_not_ignored(client)
             and client.is_oidc_client()
+            and not client.is_realm_specific_client()
             and (not client.is_public())
             and client.has_standard_flow_enabled()
         )

--- a/kcwarden/auditors/client/public_client_should_disable_direct_access_grants.py
+++ b/kcwarden/auditors/client/public_client_should_disable_direct_access_grants.py
@@ -12,10 +12,11 @@ class PublicClientShouldDisableDirectAccessGrants(Auditor):
         # We are interested in clients that are:
         # - OIDC clients
         # - Are public clients
-        return (self.is_not_ignored(client) 
-                and not client.is_realm_specific_client()
-                and client.is_oidc_client() 
-                and client.is_public()
+        return (
+            self.is_not_ignored(client)
+            and not client.is_realm_specific_client()
+            and client.is_oidc_client()
+            and client.is_public()
         )
 
     def client_uses_direct_access_grants(self, client) -> bool:

--- a/kcwarden/auditors/client/public_client_should_disable_direct_access_grants.py
+++ b/kcwarden/auditors/client/public_client_should_disable_direct_access_grants.py
@@ -12,7 +12,11 @@ class PublicClientShouldDisableDirectAccessGrants(Auditor):
         # We are interested in clients that are:
         # - OIDC clients
         # - Are public clients
-        return self.is_not_ignored(client) and client.is_oidc_client() and client.is_public()
+        return (self.is_not_ignored(client) 
+                and not client.is_realm_specific_client()
+                and client.is_oidc_client() 
+                and client.is_public()
+        )
 
     def client_uses_direct_access_grants(self, client) -> bool:
         # All clients with direct access grants should be reported

--- a/kcwarden/auditors/client/public_clients_must_enforce_pkce.py
+++ b/kcwarden/auditors/client/public_clients_must_enforce_pkce.py
@@ -15,6 +15,7 @@ class PublicClientsMustEnforcePKCE(Auditor):
         # - Have the standard flow enabled
         return (
             self.is_not_ignored(client)
+            and not client.is_realm_specific_client()
             and client.is_oidc_client()
             and client.is_public()
             and client.has_standard_flow_enabled()

--- a/kcwarden/custom_types/keycloak_object.py
+++ b/kcwarden/custom_types/keycloak_object.py
@@ -511,9 +511,7 @@ class Client(Dataclass):
         # management permissions. These clients behave differently from other
         # clients, so we need to exclude them from some of our standard checks.
         return (
-            self.get_realm().get_name() == "master"
-            and self.get_name().endswith("-realm")
-            and "protocol" not in self._d
+            self.get_realm().get_name() == "master" and self.get_name().endswith("-realm") and "protocol" not in self._d
         )
 
     def get_protocol(self) -> str:
@@ -530,8 +528,6 @@ class Client(Dataclass):
             # This case should never happen, so instead of blindly returning something,
             # we'd like to know about it. Raise an exception.
             raise RuntimeError("'protocol' field of Client {} is not set, aborting".format(self.get_name()))
-
-
 
     def is_oidc_client(self) -> bool:
         return self.get_protocol() == "openid-connect"

--- a/kcwarden/custom_types/keycloak_object.py
+++ b/kcwarden/custom_types/keycloak_object.py
@@ -505,13 +505,33 @@ class Client(Dataclass):
         return "service-account-" + self.get_client_id().lower()
 
     # More Specific Properties
+    def is_realm_specific_client(self) -> bool:
+        # Each realm in Keycloak will get a realm-specific client created in the
+        # master realm. This is used to hold realm-specific roles, like the user
+        # management permissions. These clients behave differently from other
+        # clients, so we need to exclude them from some of our standard checks.
+        return (
+            self.get_realm().get_name() == "master"
+            and self.get_name().endswith("-realm")
+            and "protocol" not in self._d
+        )
+
     def get_protocol(self) -> str:
         # Every client should have the "protocol" field set, but the "master-realm"
         # client in the "master" realm for some reason does not include this field.
         # This code works around that by returning openid-connect in that case.
-        if self.get_name() == "master-realm" and self.get_realm().get_name() == "master":
-            return "openid-connect"
-        return self._d["protocol"]
+        try:
+            return self._d["protocol"]
+        except KeyError:
+            # If the client is a realm-specific client, it for some reason does not
+            # have a "protocol" set. Return openid-connect anyway.
+            if self.is_realm_specific_client():
+                return "openid-connect"
+            # This case should never happen, so instead of blindly returning something,
+            # we'd like to know about it. Raise an exception.
+            raise RuntimeError("'protocol' field of Client {} is not set, aborting".format(self.get_name()))
+
+
 
     def is_oidc_client(self) -> bool:
         return self.get_protocol() == "openid-connect"
@@ -568,7 +588,6 @@ class Client(Dataclass):
             "broker",
             "realm-management",
             "security-admin-console",
-            "master-realm",
         ]
 
     def allows_user_authentication(self) -> bool:

--- a/tests/auditors/client/test_client_with_default_offline_access_scope.py
+++ b/tests/auditors/client/test_client_with_default_offline_access_scope.py
@@ -79,6 +79,7 @@ class TestClientWithDefaultOfflineAccessScope:
         client1.allows_user_authentication.return_value = True
         client1.get_attributes.return_value = {"use.refresh.tokens": "true"}
         client1.is_public.return_value = False
+        client1.is_realm_specific_client.return_value = False
 
         client2 = Mock()
         client2.get_default_client_scopes.return_value = []
@@ -89,6 +90,7 @@ class TestClientWithDefaultOfflineAccessScope:
         client2.get_attributes.return_value = {"use.refresh.tokens": "false"}
         client2.is_public.return_value = True
         client2.allows_user_authentication.return_value = True
+        client2.is_realm_specific_client.return_value = False
 
         client3 = Mock()
         client3.get_default_client_scopes.return_value = ["offline_access"]
@@ -99,6 +101,7 @@ class TestClientWithDefaultOfflineAccessScope:
         client3.get_attributes.return_value = {"use.refresh.tokens": "true"}
         client3.is_public.return_value = False
         client3.allows_user_authentication.return_value = True
+        client3.is_realm_specific_client.return_value = False
 
         auditor._DB.get_all_clients.return_value = [client1, client2, client3]
         results = list(auditor.audit())

--- a/tests/auditors/client/test_client_with_full_scope_allowed.py
+++ b/tests/auditors/client/test_client_with_full_scope_allowed.py
@@ -58,16 +58,19 @@ class TestClientWithFullScopeAllowed:
         client1.has_full_scope_allowed.return_value = True
         client1.get_default_client_scopes.return_value = ["email"]
         client1.get_optional_client_scopes.return_value = ["profile"]
+        client1.is_realm_specific_client.return_value = False
 
         client2 = Mock()
         client2.has_full_scope_allowed.return_value = False
         client2.get_default_client_scopes.return_value = ["email", "profile"]
         client2.get_optional_client_scopes.return_value = ["address"]
+        client2.is_realm_specific_client.return_value = False
 
         client3 = Mock()
         client3.has_full_scope_allowed.return_value = True
         client3.get_default_client_scopes.return_value = ["offline_access"]
         client3.get_optional_client_scopes.return_value = []
+        client3.is_realm_specific_client.return_value = False
 
         auditor._DB.get_all_clients.return_value = [client1, client2, client3]
         results = list(auditor.audit())

--- a/tests/auditors/client/test_client_with_optional_offline_access_scope.py
+++ b/tests/auditors/client/test_client_with_optional_offline_access_scope.py
@@ -76,6 +76,7 @@ class TestClientWithOptionalOfflineAccessScope:
         client1.has_implicit_flow_enabled.return_value = False
         client1.get_attributes.return_value = {"use.refresh.tokens": "true"}
         client1.is_public.return_value = False
+        client1.is_realm_specific_client.return_value = False
 
         client2 = Mock()
         client2.get_optional_client_scopes.return_value = []
@@ -85,6 +86,7 @@ class TestClientWithOptionalOfflineAccessScope:
         client2.has_implicit_flow_enabled.return_value = False
         client2.get_attributes.return_value = {"use.refresh.tokens": "false"}
         client2.is_public.return_value = True
+        client2.is_realm_specific_client.return_value = False
 
         client3 = Mock()
         client3.get_optional_client_scopes.return_value = ["offline_access"]
@@ -94,6 +96,7 @@ class TestClientWithOptionalOfflineAccessScope:
         client3.has_implicit_flow_enabled.return_value = True
         client3.get_attributes.return_value = {"use.refresh.tokens": "true"}
         client3.is_public.return_value = False
+        client3.is_realm_specific_client.return_value = False
 
         auditor._DB.get_all_clients.return_value = [client1, client2, client3]
         results = list(auditor.audit())

--- a/tests/auditors/client/test_client_with_service_account_and_other_flow_enabled.py
+++ b/tests/auditors/client/test_client_with_service_account_and_other_flow_enabled.py
@@ -90,6 +90,7 @@ class TestClientWithServiceAccountAndOtherFlowEnabled:
         client1.has_device_authorization_grant_flow_enabled.return_value = True
         client1.has_standard_flow_enabled.return_value = True
         client1.allows_user_authentication.return_value = True
+        client1.is_realm_specific_client.return_value = False
 
         client2 = Mock()
         client2.is_oidc_client.return_value = True
@@ -99,7 +100,8 @@ class TestClientWithServiceAccountAndOtherFlowEnabled:
         client2.has_implicit_flow_enabled.return_value = False
         client2.has_device_authorization_grant_flow_enabled.return_value = False
         client2.has_standard_flow_enabled.return_value = False
-        client1.allows_user_authentication.return_value = False
+        client2.allows_user_authentication.return_value = False
+        client2.is_realm_specific_client.return_value = False
 
         client3 = Mock()
         client3.is_oidc_client.return_value = True
@@ -110,6 +112,7 @@ class TestClientWithServiceAccountAndOtherFlowEnabled:
         client3.has_standard_flow_enabled.return_value = True
         client3.has_device_authorization_grant_flow_enabled.return_value = False
         client3.allows_user_authentication.return_value = True
+        client3.is_realm_specific_client.return_value = False
 
         auditor._DB.get_all_clients.return_value = [client1, client2, client3]
         results = list(auditor.audit())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -135,6 +135,7 @@ def mock_client(mock_realm):
     client.get_default_client_scopes.return_value = []
     client.get_optional_client_scopes.return_value = []
     client.is_oidc_client.return_value = True
+    client.is_realm_specific_client.return_value = False
     return client
 
 


### PR DESCRIPTION
This fixes #17 by changing the handling of the realm-specific clients in the master realm. It also fixes #16, because the relevant clients for some reason claim to have the standard flow enabled (even though they have no such thing), which was confusing the auditors.