### PR TITLE
Fix IDP ignore lists not working

### DIFF
--- a/kcwarden/auditors/idp/identity_provider_with_mappers_without_force_sync_mode.py
+++ b/kcwarden/auditors/idp/identity_provider_with_mappers_without_force_sync_mode.py
@@ -19,6 +19,9 @@ class IdentityProviderWithMappersWithoutForceSyncMode(Auditor):
 
     def audit(self):
         for idp in self._DB.get_all_identity_providers():
+            # Skip IDPs that were explicitly ignored
+            if not self.should_consider_idp(idp):
+                continue
             # We are looking for IDPs that do not use the "Force" sync mode
             if self.idp_uses_sync_mode_force(idp):
                 continue

--- a/kcwarden/auditors/idp/identity_provider_with_one_time_sync.py
+++ b/kcwarden/auditors/idp/identity_provider_with_one_time_sync.py
@@ -16,6 +16,9 @@ class IdentityProviderWithOneTimeSync(Auditor):
 
     def audit(self):
         for idp in self._DB.get_all_identity_providers():
+            # Skip IDPs that were explicitly ignored
+            if not self.should_consider_idp(idp):
+                continue
             # We are looking for IDPs that do not use the "Force" sync mode
             if self.idp_does_not_use_force_sync_mode(idp):
                 yield self.generate_finding(idp)

--- a/kcwarden/auditors/idp/oidc_identity_provider_without_pkce.py
+++ b/kcwarden/auditors/idp/oidc_identity_provider_without_pkce.py
@@ -9,10 +9,9 @@ class OIDCIdentityProviderWithoutPKCE(Auditor):
     REFERENCE = "https://datatracker.ietf.org/doc/html/draft-ietf-oauth-security-topics-23#section-2.1.1"
 
     def should_consider_idp(self, idp) -> bool:
-        # TODO Support the ignore list from the config here
         # We are interested in identity providers that are:
         # - using either the "oidc" or the "keycloak-oidc" provider (the others don't allow configuring the setting)
-        return idp.get_provider_id() in ["oidc", "keycloak-oidc"]
+        return idp.get_provider_id() in ["oidc", "keycloak-oidc"] and self.is_not_ignored(idp)
 
     def idp_does_not_enforce_pkce(self, cfg) -> bool:
         # TODO Refactor with .get once unit tests exist

--- a/tests/auditors/idp/test_identity_provider_with_mappers_without_force_sync_mode.py
+++ b/tests/auditors/idp/test_identity_provider_with_mappers_without_force_sync_mode.py
@@ -4,6 +4,7 @@ from unittest.mock import Mock
 from kcwarden.auditors.idp.identity_provider_with_mappers_without_force_sync_mode import (
     IdentityProviderWithMappersWithoutForceSyncMode,
 )
+from kcwarden.custom_types import config_keys
 
 
 class TestIdentityProviderWithMappersWithoutForceSyncMode:
@@ -76,3 +77,21 @@ class TestIdentityProviderWithMappersWithoutForceSyncMode:
         auditor._DB.get_all_identity_providers.return_value = [idp1, idp2, idp3]
         results = list(auditor.audit())
         assert len(results) == 1  # Expect findings from idp1 only
+
+    def test_ignore_list_functionality(self, auditor, mock_idp):
+        # Setup IDP without force sync mode and with mappers
+        mock_idp.get_sync_mode.return_value = "INHERIT"
+        mock_idp.get_identity_provider_mappers.return_value = [{"name": "mapper1"}]
+        mock_idp.get_alias.return_value = "ignored_idp"
+        mock_idp.get_name.return_value = mock_idp.get_alias.return_value
+        auditor._DB.get_all_identity_providers.return_value = [mock_idp]
+
+        # Add the IDP to the ignore list
+        auditor._CONFIG = {
+            config_keys.AUDITOR_CONFIG: {
+                auditor.get_classname(): ["ignored_idp"]
+            }
+        }
+
+        results = list(auditor.audit())
+        assert len(results) == 0  # No findings due to ignore list

--- a/tests/auditors/idp/test_identity_provider_with_mappers_without_force_sync_mode.py
+++ b/tests/auditors/idp/test_identity_provider_with_mappers_without_force_sync_mode.py
@@ -87,11 +87,7 @@ class TestIdentityProviderWithMappersWithoutForceSyncMode:
         auditor._DB.get_all_identity_providers.return_value = [mock_idp]
 
         # Add the IDP to the ignore list
-        auditor._CONFIG = {
-            config_keys.AUDITOR_CONFIG: {
-                auditor.get_classname(): ["ignored_idp"]
-            }
-        }
+        auditor._CONFIG = {config_keys.AUDITOR_CONFIG: {auditor.get_classname(): ["ignored_idp"]}}
 
         results = list(auditor.audit())
         assert len(results) == 0  # No findings due to ignore list

--- a/tests/auditors/idp/test_identity_provider_with_one_time_sync.py
+++ b/tests/auditors/idp/test_identity_provider_with_one_time_sync.py
@@ -70,11 +70,7 @@ class TestIdentityProviderWithOneTimeSync:
         auditor._DB.get_all_identity_providers.return_value = [mock_idp]
 
         # Add the IDP to the ignore list
-        auditor._CONFIG = {
-            config_keys.AUDITOR_CONFIG: {
-                auditor.get_classname(): ["ignored_idp"]
-            }
-        }
+        auditor._CONFIG = {config_keys.AUDITOR_CONFIG: {auditor.get_classname(): ["ignored_idp"]}}
 
         results = list(auditor.audit())
         assert len(results) == 0  # No findings due to ignore list

--- a/tests/auditors/idp/test_oidc_identity_provider_without_pkce.py
+++ b/tests/auditors/idp/test_oidc_identity_provider_without_pkce.py
@@ -87,11 +87,7 @@ class TestOIDCIdentityProviderWithoutPKCE:
         auditor._DB.get_all_identity_providers.return_value = [mock_idp]
 
         # Add the IDP to the ignore list
-        auditor._CONFIG = {
-            config_keys.AUDITOR_CONFIG: {
-                auditor.get_classname(): ["ignored_idp"]
-            }
-        }
+        auditor._CONFIG = {config_keys.AUDITOR_CONFIG: {auditor.get_classname(): ["ignored_idp"]}}
 
         results = list(auditor.audit())
         assert len(results) == 0  # No findings due to ignore list


### PR DESCRIPTION
While looking through the code to check on something else, I noticed that two of the IDP checks do not actually respect the ignore lists from the configuration. This pull request fixes that.

I also noticed that we currently do not have any unit tests that check the ignore logic. This should be added - I opened #35 for that.