### PR TITLE
Bugfix: Add new IDP check to auditor list to activate it

### DIFF
--- a/kcwarden/auditors/idp_auditor.py
+++ b/kcwarden/auditors/idp_auditor.py
@@ -3,7 +3,9 @@ from kcwarden.auditors.idp.identity_provider_with_mappers_without_force_sync_mod
 )
 from kcwarden.auditors.idp.identity_provider_with_one_time_sync import IdentityProviderWithOneTimeSync
 from kcwarden.auditors.idp.oidc_identity_provider_without_pkce import OIDCIdentityProviderWithoutPKCE
-from kcwarden.auditors.idp.identity_provider_with_signature_verification_disabled import IdentityProviderWithSignatureVerificationDisabled
+from kcwarden.auditors.idp.identity_provider_with_signature_verification_disabled import (
+    IdentityProviderWithSignatureVerificationDisabled,
+)
 
 # TODO Refactor this bit out of here to get rid of this file.
 # Idea: Rely on the auto-import logic that will be the basis for the plugin infrastructure?
@@ -13,5 +15,5 @@ AUDITORS = [
     OIDCIdentityProviderWithoutPKCE,
     IdentityProviderWithOneTimeSync,
     IdentityProviderWithMappersWithoutForceSyncMode,
-    IdentityProviderWithSignatureVerificationDisabled
+    IdentityProviderWithSignatureVerificationDisabled,
 ]

--- a/kcwarden/auditors/idp_auditor.py
+++ b/kcwarden/auditors/idp_auditor.py
@@ -3,6 +3,7 @@ from kcwarden.auditors.idp.identity_provider_with_mappers_without_force_sync_mod
 )
 from kcwarden.auditors.idp.identity_provider_with_one_time_sync import IdentityProviderWithOneTimeSync
 from kcwarden.auditors.idp.oidc_identity_provider_without_pkce import OIDCIdentityProviderWithoutPKCE
+from kcwarden.auditors.idp.identity_provider_with_signature_verification_disabled import IdentityProviderWithSignatureVerificationDisabled
 
 # TODO Refactor this bit out of here to get rid of this file.
 # Idea: Rely on the auto-import logic that will be the basis for the plugin infrastructure?
@@ -12,4 +13,5 @@ AUDITORS = [
     OIDCIdentityProviderWithoutPKCE,
     IdentityProviderWithOneTimeSync,
     IdentityProviderWithMappersWithoutForceSyncMode,
+    IdentityProviderWithSignatureVerificationDisabled
 ]


### PR DESCRIPTION
In #37, I forgot to add the new IDP auditor to the auditor list, which means that it is currently not being used. (We should really get around to implementing #25 to get rid of this crutch)