### PR TITLE
Fix: Ignore disabled clients in monitors when enabled

### DIFF
--- a/kcwarden/monitors/protocol_mapper/protocol_mapper_with_config.py
+++ b/kcwarden/monitors/protocol_mapper/protocol_mapper_with_config.py
@@ -71,6 +71,10 @@ class ProtocolMapperWithConfig(Monitor):
                 helper.get_effective_roles_for_service_account(self._DB, saccount)
             )
         return additional_details
+    
+    def _should_consider_client(self, client: Client) -> bool:
+        # Ignore clients that are disabled, if the global setting says so
+        return not self.is_ignored_disabled_client(client)
 
     def audit(self):
         custom_config = self.get_custom_config()
@@ -86,6 +90,8 @@ class ProtocolMapperWithConfig(Monitor):
 
             for client in self._DB.get_all_clients():
                 if helper.matches_list_of_regexes(client.get_name(), allowed_clients):
+                    continue
+                if not self._should_consider_client(client):
                     continue
                 # First, find all directly defined ProtocolMappers
                 for mapper in client.get_protocol_mappers():


### PR DESCRIPTION
Some of the monitors did not respect the `--ignore-disabled-clients` switch. This PR fixes that issue and closes #46 (or, to be exact, its more general case, as that issue only refers to one of the three affected monitors). 