### PR TITLE
Consider the default behavior of Keycloak that refresh tokens are…

### DIFF
--- a/kcwarden/auditors/client/client_with_default_offline_access_scope.py
+++ b/kcwarden/auditors/client/client_with_default_offline_access_scope.py
@@ -23,7 +23,7 @@ class ClientWithDefaultOfflineAccessScope(ClientAuditor):
         return (
             "offline_access" in client.get_default_client_scopes()
             and client.allows_user_authentication()
-            and client.get_attributes().get("use.refresh.tokens", "false") == "true"
+            and client.use_refresh_tokens()
         )
 
     def audit_client(self, client: Client):

--- a/kcwarden/auditors/client/client_with_optional_offline_access_scope.py
+++ b/kcwarden/auditors/client/client_with_optional_offline_access_scope.py
@@ -20,7 +20,7 @@ class ClientWithOptionalOfflineAccessScope(ClientAuditor):
         return (
             "offline_access" in client.get_optional_client_scopes()
             and client.allows_user_authentication()
-            and client.get_attributes().get("use.refresh.tokens", "false") == "true"
+            and client.use_refresh_tokens()
         )
 
     def audit_client(self, client: Client):

--- a/kcwarden/custom_types/keycloak_object.py
+++ b/kcwarden/custom_types/keycloak_object.py
@@ -574,6 +574,10 @@ class Client(Dataclass):
             or self.has_implicit_flow_enabled()
         )
 
+    def use_refresh_tokens(self) -> bool:
+        # If the attribute is not present, Keycloak defaults to true for probably legacy reasons
+        return self.get_attributes().get("use.refresh.tokens", "true") == "true"
+
 
 class Group(Dataclass):
     """

--- a/tests/auditors/client/test_client_with_default_offline_access_scope.py
+++ b/tests/auditors/client/test_client_with_default_offline_access_scope.py
@@ -17,16 +17,16 @@ class TestClientWithDefaultOfflineAccessScope:
     @pytest.mark.parametrize(
         "default_scopes,flow_status,use_refresh_tokens,expected",
         [
-            (["offline_access"], {"device": True, "direct": False, "standard": True, "implicit": False}, "true", True),
-            (["offline_access"], {"device": False, "direct": True, "standard": False, "implicit": False}, "true", True),
-            ([], {"device": True, "direct": True, "standard": True, "implicit": True}, "true", False),
+            (["offline_access"], {"device": True, "direct": False, "standard": True, "implicit": False}, True, True),
+            (["offline_access"], {"device": False, "direct": True, "standard": False, "implicit": False}, True, True),
+            ([], {"device": True, "direct": True, "standard": True, "implicit": True}, True, False),
             (
                 ["offline_access"],
                 {"device": False, "direct": False, "standard": False, "implicit": False},
-                "true",
+                True,
                 False,
             ),
-            (["offline_access"], {"device": True, "direct": True, "standard": True, "implicit": True}, "false", False),
+            (["offline_access"], {"device": True, "direct": True, "standard": True, "implicit": True}, False, False),
         ],
     )
     def test_client_can_generate_offline_tokens(
@@ -40,12 +40,12 @@ class TestClientWithDefaultOfflineAccessScope:
         mock_client.allows_user_authentication.return_value = (
             flow_status["device"] or flow_status["direct"] or flow_status["standard"] or flow_status["implicit"]
         )
-        mock_client.get_attributes.return_value = {"use.refresh.tokens": use_refresh_tokens}
+        mock_client.use_refresh_tokens.return_value = use_refresh_tokens
         assert auditor.client_can_generate_offline_tokens(mock_client) == expected
 
     def test_audit_function_no_findings(self, mock_client, auditor):
         mock_client.get_default_client_scopes.return_value = []
-        mock_client.get_attributes.return_value = {"use.refresh.tokens": "false"}
+        mock_client.use_refresh_tokens.return_value = False
         auditor._DB.get_all_clients.return_value = [mock_client]
         results = list(auditor.audit())
         assert len(results) == 0
@@ -57,7 +57,7 @@ class TestClientWithDefaultOfflineAccessScope:
         mock_client.has_standard_flow_enabled.return_value = True
         mock_client.has_implicit_flow_enabled.return_value = False
         mock_client.is_public.return_value = False
-        mock_client.get_attributes.return_value = {"use.refresh.tokens": "true"}
+        mock_client.use_refresh_tokens.return_value = True
         auditor._DB.get_all_clients.return_value = [mock_client]
         results = list(auditor.audit())
         assert len(results) == 1
@@ -77,7 +77,7 @@ class TestClientWithDefaultOfflineAccessScope:
         client1.has_standard_flow_enabled.return_value = True
         client1.has_implicit_flow_enabled.return_value = False
         client1.allows_user_authentication.return_value = True
-        client1.get_attributes.return_value = {"use.refresh.tokens": "true"}
+        client1.use_refresh_tokens.return_value = True
         client1.is_public.return_value = False
         client1.is_realm_specific_client.return_value = False
 
@@ -87,7 +87,7 @@ class TestClientWithDefaultOfflineAccessScope:
         client2.has_direct_access_grants_enabled.return_value = False
         client2.has_standard_flow_enabled.return_value = True
         client2.has_implicit_flow_enabled.return_value = False
-        client2.get_attributes.return_value = {"use.refresh.tokens": "false"}
+        client2.use_refresh_tokens.return_value = False
         client2.is_public.return_value = True
         client2.allows_user_authentication.return_value = True
         client2.is_realm_specific_client.return_value = False
@@ -98,7 +98,7 @@ class TestClientWithDefaultOfflineAccessScope:
         client3.has_direct_access_grants_enabled.return_value = False
         client3.has_standard_flow_enabled.return_value = False
         client3.has_implicit_flow_enabled.return_value = True
-        client3.get_attributes.return_value = {"use.refresh.tokens": "true"}
+        client3.use_refresh_tokens.return_value = True
         client3.is_public.return_value = False
         client3.allows_user_authentication.return_value = True
         client3.is_realm_specific_client.return_value = False

--- a/tests/auditors/client/test_client_with_optional_offline_access_scope.py
+++ b/tests/auditors/client/test_client_with_optional_offline_access_scope.py
@@ -17,16 +17,16 @@ class TestClientWithOptionalOfflineAccessScope:
     @pytest.mark.parametrize(
         "optional_scopes, flow_status, use_refresh_tokens, expected",
         [
-            (["offline_access"], {"device": True, "direct": True, "standard": True, "implicit": False}, "true", True),
-            (["offline_access"], {"device": False, "direct": True, "standard": False, "implicit": False}, "true", True),
-            ([], {"device": True, "direct": True, "standard": True, "implicit": True}, "true", False),
+            (["offline_access"], {"device": True, "direct": True, "standard": True, "implicit": False}, True, True),
+            (["offline_access"], {"device": False, "direct": True, "standard": False, "implicit": False}, True, True),
+            ([], {"device": True, "direct": True, "standard": True, "implicit": True}, True, False),
             (
                 ["offline_access"],
                 {"device": False, "direct": False, "standard": False, "implicit": False},
-                "true",
+                True,
                 False,
             ),
-            (["offline_access"], {"device": True, "direct": True, "standard": True, "implicit": True}, "false", False),
+            (["offline_access"], {"device": True, "direct": True, "standard": True, "implicit": True}, False, False),
         ],
     )
     def test_client_can_generate_offline_tokens(
@@ -40,12 +40,12 @@ class TestClientWithOptionalOfflineAccessScope:
         mock_client.allows_user_authentication.return_value = (
             flow_status["device"] or flow_status["direct"] or flow_status["standard"] or flow_status["implicit"]
         )
-        mock_client.get_attributes.return_value = {"use.refresh.tokens": use_refresh_tokens}
+        mock_client.use_refresh_tokens.return_value = use_refresh_tokens
         assert auditor.client_can_generate_offline_tokens(mock_client) == expected
 
     def test_audit_function_no_findings(self, mock_client, auditor):
         mock_client.get_optional_client_scopes.return_value = []
-        mock_client.get_attributes.return_value = {"use.refresh.tokens": "false"}
+        mock_client.use_refresh_tokens.return_value = False
         auditor._DB.get_all_clients.return_value = [mock_client]
         results = list(auditor.audit())
         assert len(results) == 0
@@ -56,7 +56,7 @@ class TestClientWithOptionalOfflineAccessScope:
         mock_client.has_direct_access_grants_enabled.return_value = True
         mock_client.has_standard_flow_enabled.return_value = True
         mock_client.has_implicit_flow_enabled.return_value = False
-        mock_client.get_attributes.return_value = {"use.refresh.tokens": "true"}
+        mock_client.use_refresh_tokens.return_value = True
         mock_client.is_public.return_value = False
         auditor._DB.get_all_clients.return_value = [mock_client]
         results = list(auditor.audit())
@@ -74,7 +74,7 @@ class TestClientWithOptionalOfflineAccessScope:
         client1.has_direct_access_grants_enabled.return_value = True
         client1.has_standard_flow_enabled.return_value = True
         client1.has_implicit_flow_enabled.return_value = False
-        client1.get_attributes.return_value = {"use.refresh.tokens": "true"}
+        client1.use_refresh_tokens.return_value = True
         client1.is_public.return_value = False
         client1.is_realm_specific_client.return_value = False
 
@@ -84,7 +84,7 @@ class TestClientWithOptionalOfflineAccessScope:
         client2.has_direct_access_grants_enabled.return_value = False
         client2.has_standard_flow_enabled.return_value = True
         client2.has_implicit_flow_enabled.return_value = False
-        client2.get_attributes.return_value = {"use.refresh.tokens": "false"}
+        client2.use_refresh_tokens.return_value = False
         client2.is_public.return_value = True
         client2.is_realm_specific_client.return_value = False
 
@@ -94,7 +94,7 @@ class TestClientWithOptionalOfflineAccessScope:
         client3.has_direct_access_grants_enabled.return_value = False
         client3.has_standard_flow_enabled.return_value = False
         client3.has_implicit_flow_enabled.return_value = True
-        client3.get_attributes.return_value = {"use.refresh.tokens": "true"}
+        client3.use_refresh_tokens.return_value = True
         client3.is_public.return_value = False
         client3.is_realm_specific_client.return_value = False
 

--- a/tests/custom_types/test_keycloak_object.py
+++ b/tests/custom_types/test_keycloak_object.py
@@ -1,0 +1,27 @@
+from unittest.mock import Mock
+
+import pytest
+
+from kcwarden.custom_types.keycloak_object import Client
+
+
+class TestClient:
+    @pytest.mark.parametrize(
+        ["attributes", "expected"],
+        [
+            ({}, True),
+            ({"use.refresh.tokens": "true"}, True),
+            ({"use.refresh.tokens": "false"}, False),
+        ],
+    )
+    def test_use_refresh_tokens(self, attributes: dict, expected: bool):
+        client = Client(
+            {
+                "clientId": "TEST_CLIENT_ID",
+                "attributes": attributes,
+            },
+            [],
+            {},
+            realm=Mock(),
+        )
+        assert client.use_refresh_tokens() == expected


### PR DESCRIPTION
…enabled if the configuration attribute is not present

Fixes #141 