### PR TITLE
New auditors: AccessTokenLifespanTooLong and ClientAccessTokenLifespanTooLong

### DIFF
--- a/docs/auditors/clients.md
+++ b/docs/auditors/clients.md
@@ -202,3 +202,9 @@ The security of the OIDC standard flow and others rely on the allowed redirect U
 This behavior is not emulated by kcwarden, and thus other auditors do not produce correct findings. 
 In addition, Keycloak's fallback mechanism might change over time and can lead to unexpected behavior. 
 It is highly recommended to explicitly set the redirect URIs for this client.
+
+## ClientAccessTokenLifespanTooLong
+
+The auditor triggers if a client sets an override for the access token lifespan
+and if the value is too long.
+See the realm auditor [AccessTokenLifespanTooLong](./realm.md#AccessTokenLifespanTooLong) for details.

--- a/docs/auditors/realm.md
+++ b/docs/auditors/realm.md
@@ -105,3 +105,12 @@ This auditor examines the password policy configuration in each realm to determi
 Note that this check is not applicable to the argon2 algorithm, which uses a different approach to password hashing that doesn't rely solely on iteration count, and the parameters cannot be configured in Keycloak.
 
 Administrators should ensure that password hashing configurations meet or exceed these minimum recommendations to provide adequate protection against brute force attacks on password hashes. Increasing the iteration count enhances security but may also increase CPU usage during authentication, so a balance should be struck based on the specific security requirements and available resources.
+
+## AccessTokenLifespanTooLong
+
+This auditor ensures that the access token lifespan has a short value.
+Access tokens should have a short lifespan to minimize the impact of potential token compromise.
+An attacker can use it until it expires.
+Since an access token is stateless, it cannot be revoked.
+The worst case is a configured lifespan of `0` since that leads to unlimited validity of the tokens.
+A recommended lifespan is 1 to 5 minutes, or 10 minutes at maximum.

--- a/kcwarden/auditors/client/client_access_token_lifespan_too_long.py
+++ b/kcwarden/auditors/client/client_access_token_lifespan_too_long.py
@@ -1,0 +1,40 @@
+from kcwarden.api.auditor import ClientAuditor
+from kcwarden.auditors.subchecks.access_tokens import (
+    MAX_ACCESS_TOKEN_LIFESPAN_SECONDS,
+    access_token_lifespan_is_too_long,
+)
+from kcwarden.custom_types.keycloak_object import Client
+from kcwarden.custom_types.result import Severity
+
+
+class ClientAccessTokenLifespanTooLong(ClientAuditor):
+    DEFAULT_SEVERITY = Severity.High
+    SHORT_DESCRIPTION = "Access token lifespan override too long"
+    LONG_DESCRIPTION = (
+        "Client-specific token lifespan overrides should be short "
+        "to minimize the potential impact of token compromise. "
+        "Consider removing the client-specific override or reducing it to "
+        f"{MAX_ACCESS_TOKEN_LIFESPAN_SECONDS / 60:.0f} minutes or less."
+    )
+    REFERENCE = ""
+
+    def should_consider_client(self, client: Client) -> bool:
+        return super().should_consider_client(client) and client.is_oidc_client()
+
+    @staticmethod
+    def client_has_access_token_lifespan_override_too_long(client: Client) -> bool:
+        override_lifespan = client.get_access_token_lifespan_override()
+        if override_lifespan is None:
+            return False
+        return access_token_lifespan_is_too_long(override_lifespan)
+
+    def audit_client(self, client: Client):
+        if self.client_has_access_token_lifespan_override_too_long(client):
+            override_lifespan = client.get_access_token_lifespan_override()
+            yield self.generate_finding(
+                client,
+                additional_details={
+                    "client_access_token_lifespan": override_lifespan,
+                    "realm_access_token_lifespan": client.get_realm().get_access_token_lifespan(),
+                },
+            )

--- a/kcwarden/auditors/realm/access_token_lifespan_too_long.py
+++ b/kcwarden/auditors/realm/access_token_lifespan_too_long.py
@@ -1,0 +1,34 @@
+from typing import Generator
+
+from kcwarden.auditors.realm.abstract_realm_auditor import AbstractRealmAuditor
+from kcwarden.auditors.subchecks.access_tokens import (
+    access_token_lifespan_is_too_long,
+    MAX_ACCESS_TOKEN_LIFESPAN_SECONDS,
+)
+from kcwarden.custom_types.keycloak_object import Realm
+from kcwarden.custom_types.result import Severity, Result
+
+
+class AccessTokenLifespanTooLong(AbstractRealmAuditor):
+    DEFAULT_SEVERITY = Severity.High
+    SHORT_DESCRIPTION = "Access token lifespan too long"
+    LONG_DESCRIPTION = (
+        "Access tokens should have a short lifespan to minimize the impact of potential token "
+        "compromise. The lifespan should be set to "
+        f"{MAX_ACCESS_TOKEN_LIFESPAN_SECONDS / 60:.0f} minutes or less."
+    )
+    REFERENCE = ""
+
+    @staticmethod
+    def realm_has_access_token_lifespan_too_long(realm: Realm) -> bool:
+        """Check if realm's access token lifespan exceeds the maximum allowed duration."""
+        return access_token_lifespan_is_too_long(realm.get_access_token_lifespan())
+
+    def audit_realm(self, realm: Realm) -> Generator[Result, None, None]:
+        if self.realm_has_access_token_lifespan_too_long(realm):
+            yield self.generate_finding(
+                realm,
+                additional_details={
+                    "realm_access_token_lifespan": realm.get_access_token_lifespan(),
+                },
+            )

--- a/kcwarden/auditors/subchecks/access_tokens.py
+++ b/kcwarden/auditors/subchecks/access_tokens.py
@@ -1,0 +1,6 @@
+MAX_ACCESS_TOKEN_LIFESPAN_SECONDS = 600  # 10 minutes
+
+
+def access_token_lifespan_is_too_long(lifespan: int) -> bool:
+    # 0 means unlimited
+    return lifespan <= 0 or lifespan > MAX_ACCESS_TOKEN_LIFESPAN_SECONDS

--- a/kcwarden/custom_types/keycloak_object.py
+++ b/kcwarden/custom_types/keycloak_object.py
@@ -51,6 +51,10 @@ class Realm(Dataclass):
     def get_refresh_token_maximum_reuse_count(self) -> int:
         return self._d["refreshTokenMaxReuse"]
 
+    def get_access_token_lifespan(self) -> int:
+        """Get access token lifespan in seconds."""
+        return self._d["accessTokenLifespan"]
+
     def get_unmanaged_attribute_policy(self) -> str | None:
         return self._d["attributes"].get("unmanagedAttributePolicy")
 
@@ -574,6 +578,16 @@ class Client(Dataclass):
     def use_refresh_tokens(self) -> bool:
         # If the attribute is not present, Keycloak defaults to true for probably legacy reasons
         return self.get_attributes().get("use.refresh.tokens", "true") == "true"
+
+    def get_access_token_lifespan_override(self) -> int | None:
+        """Get client-specific access token lifespan override in seconds, if set."""
+        lifespan_str = self.get_attributes().get("access.token.lifespan")
+        if lifespan_str is None:
+            return None
+        try:
+            return int(lifespan_str)
+        except ValueError:
+            return None
 
 
 class Group(Dataclass):

--- a/tests/auditors/client/test_client_access_token_lifespan_too_long.py
+++ b/tests/auditors/client/test_client_access_token_lifespan_too_long.py
@@ -1,0 +1,147 @@
+import pytest
+from unittest.mock import Mock
+
+from kcwarden.auditors.client.client_access_token_lifespan_too_long import ClientAccessTokenLifespanTooLong
+
+
+class TestClientAccessTokenLifespanTooLong:
+    @pytest.fixture
+    def auditor(self, database, default_config):
+        auditor_instance = ClientAccessTokenLifespanTooLong(database, default_config)
+        auditor_instance._DB = Mock()
+        return auditor_instance
+
+    @pytest.mark.parametrize(
+        "is_oidc, expected",
+        [
+            (True, True),  # OIDC client - should consider
+            (False, False),  # Not OIDC client - should not consider
+        ],
+    )
+    def test_should_consider_client(self, mock_client, auditor, is_oidc, expected):
+        mock_client.is_oidc_client.return_value = is_oidc
+        assert auditor.should_consider_client(mock_client) == expected
+
+    @pytest.mark.parametrize(
+        "override_lifespan, expected",
+        [
+            (None, False),  # No override - should not produce a finding
+            (300, False),  # 5 minutes - should not produce a finding
+            (600, False),  # 10 minutes - should not produce a finding (exactly at limit)
+            (601, True),  # 10 minutes + 1 second - should produce a finding
+            (900, True),  # 15 minutes - should produce a finding
+            (1800, True),  # 30 minutes - should produce a finding
+            (3600, True),  # 60 minutes - should produce a finding
+        ],
+    )
+    def test_client_has_access_token_lifespan_override_too_long(
+        self, mock_client, auditor, override_lifespan, expected
+    ):
+        mock_client.get_access_token_lifespan_override.return_value = override_lifespan
+        assert auditor.client_has_access_token_lifespan_override_too_long(mock_client) == expected
+
+    def test_audit_function_no_findings_no_override(self, mock_client, auditor):
+        # Setup client with no access token lifespan override
+        mock_client.get_access_token_lifespan_override.return_value = None
+        auditor._DB.get_all_clients.return_value = [mock_client]
+
+        results = list(auditor.audit())
+        assert len(results) == 0
+
+    def test_audit_function_no_findings_short_override(self, mock_client, auditor):
+        # Setup client with short access token lifespan override (5 minutes)
+        mock_client.get_access_token_lifespan_override.return_value = 300
+        mock_realm = Mock()
+        mock_realm.get_access_token_lifespan.return_value = 600
+        mock_client.get_realm.return_value = mock_realm
+        auditor._DB.get_all_clients.return_value = [mock_client]
+
+        results = list(auditor.audit())
+        assert len(results) == 0
+
+    def test_audit_function_no_findings_exact_limit(self, mock_client, auditor):
+        # Setup client with access token lifespan override of exactly 10 minutes (600 seconds)
+        mock_client.get_access_token_lifespan_override.return_value = 600
+        mock_realm = Mock()
+        mock_realm.get_access_token_lifespan.return_value = 300
+        mock_client.get_realm.return_value = mock_realm
+        auditor._DB.get_all_clients.return_value = [mock_client]
+
+        results = list(auditor.audit())
+        assert len(results) == 0
+
+    def test_audit_function_with_findings_long_override(self, mock_client, auditor):
+        # Setup client with long access token lifespan override (15 minutes)
+        mock_client.get_access_token_lifespan_override.return_value = 900
+        mock_realm = Mock()
+        mock_realm.get_access_token_lifespan.return_value = 300
+        mock_client.get_realm.return_value = mock_realm
+        auditor._DB.get_all_clients.return_value = [mock_client]
+
+        results = list(auditor.audit())
+        assert len(results) == 1
+
+        # Verify the finding contains expected additional details
+        finding = results[0]
+        assert finding.additional_details["client_access_token_lifespan"] == 900
+        assert finding.additional_details["realm_access_token_lifespan"] == 300
+
+    def test_audit_function_multiple_clients_mixed_overrides(self, auditor):
+        # Create separate mock clients with distinct token lifespan overrides
+        mock_realm = Mock()
+        mock_realm.get_access_token_lifespan.return_value = 300
+
+        client1 = Mock()
+        client1.get_access_token_lifespan_override.return_value = None  # No override - OK
+        client1.get_realm.return_value = mock_realm
+        client1.is_oidc_client.return_value = True
+
+        client2 = Mock()
+        client2.get_access_token_lifespan_override.return_value = 300  # 5 minutes - OK
+        client2.get_realm.return_value = mock_realm
+        client2.is_oidc_client.return_value = True
+
+        client3 = Mock()
+        client3.get_access_token_lifespan_override.return_value = 1800  # 30 minutes - Too long
+        client3.get_realm.return_value = mock_realm
+        client3.is_oidc_client.return_value = True
+
+        client4 = Mock()
+        client4.get_access_token_lifespan_override.return_value = 900  # 15 minutes - Too long
+        client4.get_realm.return_value = mock_realm
+        client4.is_oidc_client.return_value = True
+
+        # client5 is not an OIDC client - should be ignored
+        client5 = Mock()
+        client5.get_access_token_lifespan_override.return_value = 1800  # 30 minutes but ignored
+        client5.get_realm.return_value = mock_realm
+        client5.is_oidc_client.return_value = False
+
+        auditor._DB.get_all_clients.return_value = [client1, client2, client3, client4, client5]
+        results = list(auditor.audit())
+        assert len(results) == 2  # Expect findings from client3 and client4 only
+
+    def test_audit_function_edge_case_zero_override(self, mock_client, auditor):
+        # Edge case: client with 0 second override that means unlimited
+        mock_client.get_access_token_lifespan_override.return_value = 0
+        mock_realm = Mock()
+        mock_realm.get_access_token_lifespan.return_value = 300
+        mock_client.get_realm.return_value = mock_realm
+        auditor._DB.get_all_clients.return_value = [mock_client]
+
+        results = list(auditor.audit())
+        assert len(results) == 1
+
+    def test_audit_function_edge_case_very_long_override(self, mock_client, auditor):
+        # Edge case: client with very long override (24 hours)
+        mock_client.get_access_token_lifespan_override.return_value = 86400  # 24 hours
+        mock_realm = Mock()
+        mock_realm.get_access_token_lifespan.return_value = 300
+        mock_client.get_realm.return_value = mock_realm
+        auditor._DB.get_all_clients.return_value = [mock_client]
+
+        results = list(auditor.audit())
+        assert len(results) == 1
+
+        finding = results[0]
+        assert finding.additional_details["client_access_token_lifespan"] == 86400

--- a/tests/auditors/realm/test_access_token_lifespan_too_long.py
+++ b/tests/auditors/realm/test_access_token_lifespan_too_long.py
@@ -1,0 +1,95 @@
+from unittest.mock import Mock
+
+import pytest
+
+from kcwarden.auditors.realm.access_token_lifespan_too_long import AccessTokenLifespanTooLong
+
+
+class TestAccessTokenLifespanTooLong:
+    @pytest.fixture
+    def auditor(self, mock_database, default_config):
+        return AccessTokenLifespanTooLong(mock_database, default_config)
+
+    def test_should_consider_realm(self, mock_realm, auditor):
+        assert auditor.should_consider_realm(mock_realm) is True  # Always consider unless specifically ignored
+
+    @pytest.mark.parametrize(
+        "lifespan_seconds, expected",
+        [
+            (300, False),  # 5 minutes - should not produce a finding
+            (600, False),  # 10 minutes - should not produce a finding (exactly at limit)
+            (601, True),  # 10 minutes + 1 second - should produce a finding
+            (0, True),  # unlimited - should produce a finding
+            (900, True),  # 15 minutes - should produce a finding
+            (1800, True),  # 30 minutes - should produce a finding
+            (3600, True),  # 60 minutes - should produce a finding
+        ],
+    )
+    def test_realm_has_access_token_lifespan_too_long(self, mock_realm, auditor, lifespan_seconds, expected):
+        mock_realm.get_access_token_lifespan.return_value = lifespan_seconds
+        assert auditor.realm_has_access_token_lifespan_too_long(mock_realm) == expected
+
+    def test_audit_function_no_findings_short_lifespan(self, auditor, mock_realm):
+        # Setup realm with access token lifespan of 5 minutes (300 seconds)
+        mock_realm.get_access_token_lifespan.return_value = 300
+        auditor._DB.get_all_realms.return_value = [mock_realm]
+
+        results = list(auditor.audit())
+        assert len(results) == 0
+
+    def test_audit_function_no_findings_exact_limit(self, auditor, mock_realm):
+        # Setup realm with access token lifespan of exactly 10 minutes (600 seconds)
+        mock_realm.get_access_token_lifespan.return_value = 600
+        auditor._DB.get_all_realms.return_value = [mock_realm]
+
+        results = list(auditor.audit())
+        assert len(results) == 0
+
+    def test_audit_function_with_findings_long_lifespan(self, auditor, mock_realm):
+        # Setup realm with access token lifespan of 15 minutes (900 seconds)
+        mock_realm.get_access_token_lifespan.return_value = 900
+        auditor._DB.get_all_realms.return_value = [mock_realm]
+
+        results = list(auditor.audit())
+        assert len(results) == 1
+
+        # Verify the finding contains expected additional details
+        finding = results[0]
+        assert finding.additional_details["realm_access_token_lifespan"] == 900
+
+    def test_audit_function_multiple_realms_mixed_lifespans(self, auditor):
+        # Create separate mock realms with distinct token lifespans
+        realm1 = Mock()
+        realm1.get_access_token_lifespan.return_value = 300  # 5 minutes - OK
+
+        realm2 = Mock()
+        realm2.get_access_token_lifespan.return_value = 600  # 10 minutes - OK (at limit)
+
+        realm3 = Mock()
+        realm3.get_access_token_lifespan.return_value = 1800  # 30 minutes - Too long
+
+        realm4 = Mock()
+        realm4.get_access_token_lifespan.return_value = 900  # 15 minutes - Too long
+
+        auditor._DB.get_all_realms.return_value = [realm1, realm2, realm3, realm4]
+        results = list(auditor.audit())
+        assert len(results) == 2  # Expect findings from realm3 and realm4
+
+    def test_audit_function_edge_case_zero_lifespan(self, auditor, mock_realm):
+        # Edge case: realm with 0 second lifespan that means unlimited
+        mock_realm.get_access_token_lifespan.return_value = 0
+        auditor._DB.get_all_realms.return_value = [mock_realm]
+
+        results = list(auditor.audit())
+        assert len(results) == 1
+
+    def test_audit_function_edge_case_very_long_lifespan(self, auditor, mock_realm):
+        # Edge case: realm with a very long lifespan (24 hours)
+        mock_realm.get_access_token_lifespan.return_value = 86400  # 24 hours
+        auditor._DB.get_all_realms.return_value = [mock_realm]
+
+        results = list(auditor.audit())
+        assert len(results) == 1
+
+        finding = results[0]
+        assert finding.additional_details["realm_access_token_lifespan"] == 86400


### PR DESCRIPTION
Implements #21.

Currently, it does not handle the critical value of  `0` dedicated, but it is captured by the auditors (better than nothing). I've created #154 for the future work.

Disclosure: this was partly generated using AI tools for code development. It was reworked and adapted by a human (me), but might deserve extra scrutiny.