### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -11,6 +11,8 @@ env:
 jobs:
   test-and-build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     env:
       PIP_PROGRESS_BAR: "off"


### PR DESCRIPTION
Potential fix for [https://github.com/iteratec/kcwarden/security/code-scanning/2](https://github.com/iteratec/kcwarden/security/code-scanning/2)

To fix the problem, add an explicit `permissions` block to the `test-and-build` job to restrict the `GITHUB_TOKEN` permissions to the minimum required. Since the job does not appear to push, write, or modify any repository resources, the minimal `contents: read` permission is sufficient. The change should be made under the `test-and-build:` job definition, at the same indentation level as `runs-on`. This does not affect existing functionality―the job and steps remain unchanged.

- Add:
  ```yaml
  permissions:
    contents: read
  ```
  immediately under:
  ```yaml
  test-and-build:
    runs-on: ubuntu-latest
  ```


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
