### PR TITLE
New Auditor: OfflineSessionMaxLifespanDisabled

### DIFF
--- a/docs/auditors/realm.md
+++ b/docs/auditors/realm.md
@@ -121,3 +121,9 @@ An attacker can use it until it expires.
 Since an access token is stateless, it cannot be revoked.
 The worst case is a configured lifespan of `0` since that leads to unlimited validity of the tokens.
 A recommended lifespan is 1 to 5 minutes, or 10 minutes at maximum.
+
+## OfflineSessionMaxLifespanDisabled
+
+This auditor flags realms where the maximum lifespan for offline sessions is not enforced.
+When this setting is disabled (which is the Keycloak default), offline tokens can be renewed indefinitely as long as they are used within the idle timeout, effectively granting permanent access.
+In environments with upstream identity providers or strict session governance requirements, this undermines token revocation and session expiry controls.

--- a/kcwarden/auditors/realm/offline_session_max_lifespan_disabled.py
+++ b/kcwarden/auditors/realm/offline_session_max_lifespan_disabled.py
@@ -22,9 +22,4 @@ class OfflineSessionMaxLifespanDisabled(AbstractRealmAuditor):
 
     def audit_realm(self, realm: Realm) -> Generator[Result, None, None]:
         if self.realm_has_offline_session_max_lifespan_disabled(realm):
-            yield self.generate_finding(
-                realm,
-                additional_details={
-                    "offline_session_idle_timeout": realm.get_offline_session_idle_timeout(),
-                },
-            )
+            yield self.generate_finding(realm)

--- a/kcwarden/custom_types/keycloak_object.py
+++ b/kcwarden/custom_types/keycloak_object.py
@@ -60,9 +60,6 @@ class Realm(Dataclass):
     def is_offline_session_max_lifespan_enabled(self) -> bool:
         return self._d["offlineSessionMaxLifespanEnabled"]
 
-    def get_offline_session_idle_timeout(self) -> int:
-        return self._d["offlineSessionIdleTimeout"]
-
     def get_unmanaged_attribute_policy(self) -> str | None:
         try:
             attribute_config = json.loads(

--- a/tests/auditors/realm/test_offline_session_max_lifespan_disabled.py
+++ b/tests/auditors/realm/test_offline_session_max_lifespan_disabled.py
@@ -33,26 +33,20 @@ class TestOfflineSessionMaxLifespanDisabled:
 
     def test_audit_function_with_findings(self, auditor, mock_realm):
         mock_realm.is_offline_session_max_lifespan_enabled.return_value = False
-        mock_realm.get_offline_session_idle_timeout.return_value = 2592000
         auditor._DB.get_all_realms.return_value = [mock_realm]
 
         results = list(auditor.audit())
         assert len(results) == 1
 
-        finding = results[0]
-        assert finding.additional_details["offline_session_idle_timeout"] == 2592000
-
     def test_audit_function_multiple_realms(self, auditor):
         realm1 = Mock()
         realm1.is_offline_session_max_lifespan_enabled.return_value = False
-        realm1.get_offline_session_idle_timeout.return_value = 2592000
 
         realm2 = Mock()
         realm2.is_offline_session_max_lifespan_enabled.return_value = True
 
         realm3 = Mock()
         realm3.is_offline_session_max_lifespan_enabled.return_value = False
-        realm3.get_offline_session_idle_timeout.return_value = 1296000
 
         auditor._DB.get_all_realms.return_value = [realm1, realm2, realm3]
         results = list(auditor.audit())


### PR DESCRIPTION
Adds an informational realm auditor that flags realms where `offlineSessionMaxLifespanEnabled` is disabled (Keycloak default), allowing offline tokens to be renewed indefinitely.

Closes #140