### PR TITLE
Add auditor for undefined scheme in post_logout_redirect_uris

### DIFF
--- a/docs/auditors/clients.md
+++ b/docs/auditors/clients.md
@@ -96,6 +96,15 @@ This auditor identifies clients where the redirect URI, in combination with the 
 This often indicates that a fully qualified domain name, including the scheme (e.g., 'https://example.com/login'), is not defined for either the client root URL or the redirect URIs.
 To address this issue, clients should specify clear redirect URIs with proper schemes to enhance security.
 
+## ClientHasUndefinedBaseDomainAndSchemaInPostLogoutRedirectUri
+
+This auditor checks if OIDC clients have undefined or insufficiently specified `post_logout_redirect_uri` schemes.
+After an RP-initiated logout, the OpenID Provider redirects the user back to the Relying Party using a URI from the client's registered `post_logout_redirect_uris`.
+According to the [OIDC RP-Initiated Logout specification](https://openid.net/specs/openid-connect-rpinitiated-1_0.html#ClientMetadata), these URIs should use the HTTPS scheme.
+This auditor identifies clients where a `post_logout_redirect_uri`, in combination with the client's root URL, does not resolve to a fully qualified address with a defined scheme.
+The specification requires the OpenID Provider to redirect to one of the registered `post_logout_redirect_uris` values; a URI without a defined scheme cannot be successfully resolved, and Keycloak will display an "invalid redirect uri" error page instead of redirecting the user back to the application.
+To address this issue, clients should specify fully qualified `post_logout_redirect_uris` including the scheme (e.g., `https://example.com/logout`).
+
 ## ClientShouldNotUseWildcardRedirectURI
 
 This auditor focuses on identifying OIDC clients within Keycloak that use wildcard characters in their `redirect_uri` configurations.

--- a/kcwarden/auditors/client/client_has_undefined_base_domain_and_schema_in_post_logout_redirect_uri.py
+++ b/kcwarden/auditors/client/client_has_undefined_base_domain_and_schema_in_post_logout_redirect_uri.py
@@ -1,0 +1,41 @@
+import urllib.parse
+
+from kcwarden.api.auditor import ClientAuditor
+from kcwarden.custom_types.keycloak_object import Client
+from kcwarden.custom_types.result import Severity
+
+# Keycloak special value: inherit post-logout redirect URIs from the client's redirect URIs
+_KEYCLOAK_INHERIT = "+"
+
+
+class ClientHasUndefinedBaseDomainAndSchemaInPostLogoutRedirectUri(ClientAuditor):
+    DEFAULT_SEVERITY = Severity.Info
+    SHORT_DESCRIPTION = "Client post-logout redirect URI scheme undefined, cannot be audited"
+    LONG_DESCRIPTION = (
+        "After an RP-initiated logout, the OpenID Provider redirects the user back to the Relying Party "
+        "using a URI from the client's registered post_logout_redirect_uris. "
+        "According to the OIDC RP-Initiated Logout specification, these URIs should use the HTTPS scheme "
+        "and must not contain a fragment component. "
+        "For this client, the scheme of a post-logout redirect URI could not be determined, because the URI "
+        "combined with the client's root URL does not resolve to a fully qualified address. "
+        "An unresolvable URI cannot be safely used for post-logout redirection and will silently fail. "
+        "To remediate, define a fully qualified URI including scheme "
+        "(e.g. 'https://example.com/logout') for the post_logout_redirect_uris or the client root URL."
+    )
+    REFERENCE = "https://openid.net/specs/openid-connect-rpinitiated-1_0.html#RedirectionAfterLogout"
+
+    def should_consider_client(self, client: Client) -> bool:
+        return (
+            super().should_consider_client(client) and not client.is_realm_specific_client() and client.is_oidc_client()
+        )
+
+    @staticmethod
+    def post_logout_redirect_uri_has_empty_scheme(uri: str) -> bool:
+        return urllib.parse.urlparse(uri).scheme == ""
+
+    def audit_client(self, client: Client):
+        for uri in client.get_resolved_post_logout_redirect_uris():
+            if uri == _KEYCLOAK_INHERIT:
+                continue
+            if self.post_logout_redirect_uri_has_empty_scheme(uri):
+                yield self.generate_finding(client, additional_details={"post_logout_redirect_uri": uri})

--- a/kcwarden/custom_types/keycloak_object.py
+++ b/kcwarden/custom_types/keycloak_object.py
@@ -632,6 +632,20 @@ class Client(Dataclass):
                 rv.append(uri)
         return rv
 
+    def get_post_logout_redirect_uris(self) -> list[str]:
+        # Stored in attributes as a ##-separated string; "+" means "inherit from redirect URIs"
+        raw = self._d.get("attributes", {}).get("post.logout.redirect.uris", "")
+        if not raw:
+            return []
+        return raw.split("##")
+
+    def get_resolved_post_logout_redirect_uris(self) -> list[str]:
+        uris = self.get_post_logout_redirect_uris()
+        if not uris:
+            return uris
+        root_url = self.get_root_url() or ""
+        return [root_url + uri if uri.startswith("/") else uri for uri in uris]
+
     def is_default_keycloak_client(self) -> bool:
         return self.get_name() in [
             "account",

--- a/tests/auditors/client/test_client_has_undefined_base_domain_and_schema_in_post_logout_redirect_uri.py
+++ b/tests/auditors/client/test_client_has_undefined_base_domain_and_schema_in_post_logout_redirect_uri.py
@@ -1,0 +1,125 @@
+import pytest
+from unittest.mock import Mock
+
+from kcwarden.auditors.client.client_has_undefined_base_domain_and_schema_in_post_logout_redirect_uri import (
+    ClientHasUndefinedBaseDomainAndSchemaInPostLogoutRedirectUri,
+)
+from kcwarden.custom_types.keycloak_object import Client, Realm
+
+
+class TestClientHasUndefinedBaseDomainAndSchemaInPostLogoutRedirectUri:
+    @pytest.fixture
+    def auditor(self, database, default_config):
+        instance = ClientHasUndefinedBaseDomainAndSchemaInPostLogoutRedirectUri(database, default_config)
+        instance._DB = Mock()
+        return instance
+
+    # --- should_consider_client ---
+
+    @pytest.mark.parametrize(
+        "is_oidc,is_realm_specific,expected",
+        [
+            (True, False, True),  # standard OIDC client
+            (False, False, False),  # non-OIDC client excluded
+            (True, True, False),  # realm-specific client excluded
+        ],
+    )
+    def test_should_consider_client(self, mock_client, auditor, is_oidc, is_realm_specific, expected):
+        mock_client.is_oidc_client.return_value = is_oidc
+        mock_client.is_realm_specific_client.return_value = is_realm_specific
+        assert auditor.should_consider_client(mock_client) == expected
+
+    # --- post_logout_redirect_uri_has_empty_scheme ---
+
+    # noinspection HttpUrlsUsage
+    @pytest.mark.parametrize(
+        "uri,should_alert",
+        [
+            ("https://example.com/logout", False),  # fully qualified HTTPS
+            ("http://example.com/logout", False),  # HTTP, defined scheme
+            ("//example.com/logout", True),  # scheme-relative
+            ("example.com/logout", True),  # no scheme at all
+            ("/logout", True),  # root-relative (after resolution still no scheme)
+        ],
+    )
+    def test_post_logout_redirect_uri_has_empty_scheme(self, auditor, uri, should_alert):
+        assert auditor.post_logout_redirect_uri_has_empty_scheme(uri) == should_alert
+
+    # --- audit_client ---
+
+    def test_no_finding_when_post_logout_uris_empty(self, mock_client, auditor):
+        mock_client.get_resolved_post_logout_redirect_uris.return_value = []
+        results = list(auditor.audit_client(mock_client))
+        assert results == []
+
+    def test_no_finding_for_inherit_special_value(self, mock_client, auditor):
+        mock_client.get_resolved_post_logout_redirect_uris.return_value = ["+"]
+        results = list(auditor.audit_client(mock_client))
+        assert results == []
+
+    def test_no_finding_for_valid_uri(self, mock_client, auditor):
+        mock_client.get_resolved_post_logout_redirect_uris.return_value = ["https://example.com/logout"]
+        results = list(auditor.audit_client(mock_client))
+        assert results == []
+
+    def test_finding_for_scheme_relative_uri(self, mock_client, auditor):
+        mock_client.get_resolved_post_logout_redirect_uris.return_value = ["//example.com/logout"]
+        results = list(auditor.audit_client(mock_client))
+        assert len(results) == 1
+        assert results[0].additional_details["post_logout_redirect_uri"] == "//example.com/logout"
+
+    def test_finding_for_uri_without_scheme(self, mock_client, auditor):
+        mock_client.get_resolved_post_logout_redirect_uris.return_value = ["example.com/logout"]
+        results = list(auditor.audit_client(mock_client))
+        assert len(results) == 1
+
+    def test_one_finding_per_invalid_uri(self, mock_client, auditor):
+        mock_client.get_resolved_post_logout_redirect_uris.return_value = [
+            "https://valid.com/logout",
+            "//invalid.com/logout",
+            "also-invalid.com/logout",
+        ]
+        results = list(auditor.audit_client(mock_client))
+        assert len(results) == 2
+
+    def test_inherit_value_mixed_with_invalid_uri(self, mock_client, auditor):
+        mock_client.get_resolved_post_logout_redirect_uris.return_value = ["+", "//bad.com/logout"]
+        results = list(auditor.audit_client(mock_client))
+        assert len(results) == 1
+
+    def test_audit_iterates_all_clients(self, mock_client, auditor):
+        mock_client.get_resolved_post_logout_redirect_uris.return_value = ["//bad.com/logout"]
+        auditor._DB.get_all_clients.return_value = [mock_client, mock_client]
+        results = list(auditor.audit())
+        assert len(results) == 2
+
+    # --- get_post_logout_redirect_uris (data model) ---
+
+    def test_get_post_logout_redirect_uris_parses_separator(self, example_db):
+        # Verify that ## separation is parsed correctly via the data model
+        realm = Mock(spec=Realm)
+        realm.get_name.return_value = "test"
+        client = Client(
+            {
+                "clientId": "test",
+                "attributes": {"post.logout.redirect.uris": "https://a.com/logout##https://b.com/logout"},
+            },
+            [],
+            {},
+            realm,
+        )
+        assert client.get_post_logout_redirect_uris() == ["https://a.com/logout", "https://b.com/logout"]
+
+    def test_get_post_logout_redirect_uris_empty_when_absent(self, example_db):
+        realm = Mock(spec=Realm)
+        realm.get_name.return_value = "test"
+        client = Client(
+            {
+                "clientId": "test",
+                "attributes": {},
+            },
+            [],
+            {},
+            realm,
+        )
+        assert client.get_post_logout_redirect_uris() == []


### PR DESCRIPTION
# Summary

- Adds `ClientHasUndefinedBaseDomainAndSchemaInPostLogoutRedirectUri`, an Info-level `ClientAuditor` that checks whether each entry in a client's `post_logout_redirect_uris` resolves to a fully qualified URI with a defined scheme.
- Mirrors the existing `ClientHasUndefinedBaseDomainAndSchema` auditor for regular redirect URIs, applying the same resolution logic (prepend `rootUrl` for relative URIs).
- Keycloak's `+` special value ("inherit from redirect URIs") is explicitly skipped.
- Adds `get_post_logout_redirect_uris()` and `get_resolved_post_logout_redirect_uris()` accessors to the Client data model, handling Keycloak's ##-separated attribute format (`attributes["post.logout.redirect.uris"]`).

# Motivation

According to the https://openid.net/specs/openid-connect-rpinitiated-1_0.html#RedirectionAfterLogout, the OpenID Provider redirects the user back to the Relying Party after logout using a URI from the client's registered `post_logout_redirect_uris`. The https://openid.net/specs/openid-connect-rpinitiated-1_0.html#ClientMetadata states these URIs **should** use the HTTPS scheme.

A `post_logout_redirect_uri` with an undefined or unresolvable scheme (e.g. `//example.com/logout` or `example.com/logout`) will be silently unusable — the OP cannot redirect to it, and the misconfiguration is not surfaced by Keycloak at configuration time.

# Test plan

- `poetry run pytest tests/auditors/client/test_client_has_undefined_base_domain_and_schema_in_post_logout_redirect_uri.py` — 18 unit tests covering `should_consider_client`, scheme detection, all edge cases including the `+` special value and `##`-separated multi-value parsing, and absent attribute handling
- `poetry run ruff check . --fix && poetry run ruff format .` — no issues

# AI disclosure

The code of this PR was created with support of Claude Code, yes.
As I don't have the proper Python knowledge, but want to contribute to this awesome project, I decided to give it a try. I'd be happy and it would be awesome if you merge this into main, do some adjustments and/or leave some comments about what to improve. I'll do my very best. ❤️
