### PR TITLE
Add auditor for wildcard webOrigins

### DIFF
--- a/docs/auditors/clients.md
+++ b/docs/auditors/clients.md
@@ -218,6 +218,13 @@ The auditor triggers if a client sets an override for the access token lifespan
 and if the value is too long.
 See the realm auditor [AccessTokenLifespanTooLong](./realm.md#AccessTokenLifespanTooLong) for details.
 
+## ClientWebOriginsMustNotUseWildcard
+
+This auditor checks if OIDC clients allow all origins for CORS requests by setting `webOrigins` to `*`.
+While the wildcard value is technically valid, it disables the browser's same-origin policy for this client, permitting any website to send cross-origin requests to it.
+This can expose the client to cross-site request forgery and data exfiltration from malicious websites.
+Instead, `webOrigins` should explicitly list only the origins that are legitimately allowed to interact with the client.
+
 ## ClientWebOriginsMustBeValid
 
 This auditor checks if the `webOrigins` entries configured for a client are valid origins as defined by [RFC 6454](https://datatracker.ietf.org/doc/html/rfc6454#section-3.2).

--- a/kcwarden/auditors/client/client_web_origins_must_not_use_wildcard.py
+++ b/kcwarden/auditors/client/client_web_origins_must_not_use_wildcard.py
@@ -1,0 +1,22 @@
+from kcwarden.api.auditor import ClientAuditor
+from kcwarden.custom_types.keycloak_object import Client
+from kcwarden.custom_types.result import Severity
+
+
+class ClientWebOriginsMustNotUseWildcard(ClientAuditor):
+    DEFAULT_SEVERITY = Severity.Medium
+    SHORT_DESCRIPTION = "Client allows all origins for CORS requests via wildcard"
+    LONG_DESCRIPTION = (
+        "The webOrigins setting controls which origins are permitted to make CORS requests to this client. "
+        "Setting it to '*' allows any origin to send cross-origin requests, bypassing the browser's same-origin policy. "
+        "This can expose the client's endpoints to cross-site request forgery and data exfiltration from malicious websites. "
+        "Instead, explicitly list only the origins that are legitimately allowed to interact with this client."
+    )
+    REFERENCE = "https://datatracker.ietf.org/doc/html/rfc6454#section-3.2"
+
+    def should_consider_client(self, client: Client) -> bool:
+        return super().should_consider_client(client) and client.is_oidc_client()
+
+    def audit_client(self, client: Client):
+        if "*" in client.get_web_origins():
+            yield self.generate_finding(client)

--- a/tests/auditors/client/test_client_web_origins_must_not_use_wildcard.py
+++ b/tests/auditors/client/test_client_web_origins_must_not_use_wildcard.py
@@ -1,0 +1,60 @@
+import pytest
+from unittest.mock import Mock
+
+from kcwarden.auditors.client.client_web_origins_must_not_use_wildcard import ClientWebOriginsMustNotUseWildcard
+from kcwarden.custom_types.result import Severity
+
+
+class TestClientWebOriginsMustNotUseWildcard:
+    @pytest.fixture
+    def auditor(self, database, default_config):
+        instance = ClientWebOriginsMustNotUseWildcard(database, default_config)
+        instance._DB = Mock()
+        return instance
+
+    # --- should_consider_client ---
+
+    @pytest.mark.parametrize(
+        "is_oidc,expected",
+        [
+            (True, True),
+            (False, False),
+        ],
+    )
+    def test_should_consider_client(self, mock_client, auditor, is_oidc, expected):
+        mock_client.is_oidc_client.return_value = is_oidc
+        assert auditor.should_consider_client(mock_client) == expected
+
+    # --- audit_client ---
+
+    def test_no_finding_when_web_origins_empty(self, mock_client, auditor):
+        mock_client.get_web_origins.return_value = []
+        results = list(auditor.audit_client(mock_client))
+        assert results == []
+
+    def test_no_finding_for_valid_origin(self, mock_client, auditor):
+        mock_client.get_web_origins.return_value = ["https://example.com"]
+        results = list(auditor.audit_client(mock_client))
+        assert results == []
+
+    def test_no_finding_for_inherit_special_value(self, mock_client, auditor):
+        mock_client.get_web_origins.return_value = ["+"]
+        results = list(auditor.audit_client(mock_client))
+        assert results == []
+
+    def test_finding_for_wildcard(self, mock_client, auditor):
+        mock_client.get_web_origins.return_value = ["*"]
+        results = list(auditor.audit_client(mock_client))
+        assert len(results) == 1
+        assert results[0].severity == Severity.Medium
+
+    def test_finding_for_wildcard_mixed_with_valid_origins(self, mock_client, auditor):
+        mock_client.get_web_origins.return_value = ["https://example.com", "*"]
+        results = list(auditor.audit_client(mock_client))
+        assert len(results) == 1
+
+    def test_audit_iterates_all_clients(self, mock_client, auditor):
+        mock_client.get_web_origins.return_value = ["*"]
+        auditor._DB.get_all_clients.return_value = [mock_client, mock_client]
+        results = list(auditor.audit())
+        assert len(results) == 2


### PR DESCRIPTION
# Summary

- Adds `ClientWebOriginsMustNotUseWildcard`, a Medium-severity `ClientAuditor` that flags OIDC clients with `webOrigins` set to `*`.
- A wildcard permits any origin to make CORS requests to the client, bypassing the browser's same-origin policy and potentially exposing the client to cross-site request forgery and data exfiltration.
- Follows up on the suggestion raised in #213.

# Test plan

- `poetry run pytest tests/auditors/client/test_client_web_origins_must_not_use_wildcard.py` — 8 unit tests
- `poetry run ruff check . --fix && poetry run ruff format .` — no issues