### PR TITLE
Configure cooldown settings for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,8 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 3
+      semver-major-days: 14
+      semver-minor-days: 3
+      semver-patch-days: 3


### PR DESCRIPTION
We'd like to avoid getting hit by supply chain attacks, so this commit should set a cooldown for all packages. Additionally, major updates occasionally break stuff, so we're taking this chance to give them 14 days to mature. Configuration based on [this documentation](https://docs.github.com/en/code-security/tutorials/secure-your-dependencies/optimizing-pr-creation-version-updates).