### PR TITLE
Add auditors for SSO session idle timeout misconfiguration

### DIFF
--- a/docs/auditors/clients.md
+++ b/docs/auditors/clients.md
@@ -234,3 +234,18 @@ Invalid entries are silently ignored by Keycloak, which can lead to unexpected C
 
 The special Keycloak values `+` (inherit allowed origins from the configured redirect URIs) and `*` (allow all origins) are accepted without a finding.
 If no `webOrigins` are configured, the auditor produces no findings.
+
+## ClientSessionIdleTimeoutNotSetWhileSsoSessionIdleTimeoutTooLong
+
+This auditor flags OIDC clients that silently inherit a long SSO session idle timeout because no session idle timeout is configured at either the realm or client level.
+
+When the realm `ssoSessionIdleTimeout` exceeds 1 hour, client sessions remain active for that full duration unless constrained by a dedicated `clientSessionIdleTimeout` at the realm level, or a `client.session.idle.timeout` override on the individual client.
+If neither is configured, affected clients — and their associated refresh tokens — remain valid for the entire SSO session idle timeout period without any independent cap.
+
+This auditor triggers when all three conditions are true:
+
+- `ssoSessionIdleTimeout > 3600s` (1 hour)
+- No realm-level `clientSessionIdleTimeout` is set (value is `0`)
+- The client has no `client.session.idle.timeout` attribute override set (value is `0` or absent)
+
+The recommended remediation is either to configure a `clientSessionIdleTimeout` at the realm level (see [SsoSessionIdleTimeoutExceedsClientSessionIdleTimeout](./realm.md#SsoSessionIdleTimeoutExceedsClientSessionIdleTimeout)), or to set a client-specific `client.session.idle.timeout` override for this client directly.

--- a/docs/auditors/realm.md
+++ b/docs/auditors/realm.md
@@ -122,6 +122,25 @@ Since an access token is stateless, it cannot be revoked.
 The worst case is a configured lifespan of `0` since that leads to unlimited validity of the tokens.
 A recommended lifespan is 1 to 5 minutes, or 10 minutes at maximum.
 
+## SsoSessionIdleTimeoutExceedsClientSessionIdleTimeout
+
+This auditor checks that long SSO session idle timeouts are paired with an appropriate client session idle timeout.
+
+When `ssoSessionIdleTimeout` is set to more than 1 hour (3600 seconds), Keycloak will keep SSO sessions — and by extension all client sessions that inherit from them — alive for an extended period of inactivity.
+If no dedicated `clientSessionIdleTimeout` is configured (value is `0`), or if the configured value is greater than or equal to `ssoSessionIdleTimeout`, the client sessions effectively inherit the long SSO timeout without any independent cap.
+
+This matters because the idle timeout also controls the lifetime of refresh tokens: a long idle timeout means refresh tokens remain valid for that same extended period, increasing the window of opportunity in case of token compromise.
+
+The recommended mitigation is to set `clientSessionIdleTimeout` to a value that is both non-zero and strictly shorter than `ssoSessionIdleTimeout`, giving client sessions and their associated refresh tokens a tighter expiry independent of the SSO session.
+
+The severity of findings scales with the configured `ssoSessionIdleTimeout`:
+
+| `ssoSessionIdleTimeout` | Severity |
+|---|---|
+| > 3600s (1 hour) | Medium |
+| ≥ 28800s (8 hours) | High |
+| ≥ 86400s (24 hours) | Critical |
+
 ## OfflineSessionMaxLifespanDisabled
 
 This auditor flags realms where the maximum lifespan for offline sessions is not enforced.

--- a/kcwarden/auditors/client/client_session_idle_timeout_not_set_while_sso_session_idle_timeout_too_long.py
+++ b/kcwarden/auditors/client/client_session_idle_timeout_not_set_while_sso_session_idle_timeout_too_long.py
@@ -1,0 +1,42 @@
+from kcwarden.api.auditor import ClientAuditor
+from kcwarden.auditors.realm.sso_session_idle_timeout_exceeds_client_session_idle_timeout import (
+    MAX_SSO_SESSION_IDLE_TIMEOUT_SECONDS,
+)
+from kcwarden.custom_types.keycloak_object import Client
+from kcwarden.custom_types.result import Severity
+
+
+class ClientSessionIdleTimeoutNotSetWhileSsoSessionIdleTimeoutTooLong(ClientAuditor):
+    DEFAULT_SEVERITY = Severity.Medium
+    SHORT_DESCRIPTION = "Client inherits long SSO session idle timeout without a client-specific override"
+    LONG_DESCRIPTION = (
+        f"The realm SSO session idle timeout exceeds {MAX_SSO_SESSION_IDLE_TIMEOUT_SECONDS // 60} minutes "
+        "and no realm-level client session idle timeout is configured, meaning all clients inherit the long "
+        "SSO session idle timeout by default. "
+        "This client does not define its own session idle timeout override, so its sessions — and the "
+        "associated refresh tokens — remain valid for the full SSO session idle timeout duration. "
+        "Consider setting a dedicated client session idle timeout on this client to limit session and "
+        "refresh token validity independently of the SSO session."
+    )
+    REFERENCE = "https://www.keycloak.org/docs/latest/server_admin/#_timeouts"
+
+    def should_consider_client(self, client: Client) -> bool:
+        return super().should_consider_client(client) and client.is_oidc_client()
+
+    def audit_client(self, client: Client):
+        realm = client.get_realm()
+        sso_idle = realm.get_sso_session_idle_timeout()
+        client_override = client.get_client_session_idle_timeout_override()
+        if (
+            sso_idle > MAX_SSO_SESSION_IDLE_TIMEOUT_SECONDS
+            and realm.get_client_session_idle_timeout() == 0
+            and client_override == 0
+        ) or (client_override > 0 and client_override >= sso_idle):
+            yield self.generate_finding(
+                client,
+                additional_details={
+                    "realm_sso_session_idle_timeout": sso_idle,
+                    "realm_client_session_idle_timeout": realm.get_client_session_idle_timeout(),
+                    "client_session_idle_timeout_override": client_override,
+                },
+            )

--- a/kcwarden/auditors/realm/sso_session_idle_timeout_exceeds_client_session_idle_timeout.py
+++ b/kcwarden/auditors/realm/sso_session_idle_timeout_exceeds_client_session_idle_timeout.py
@@ -1,0 +1,48 @@
+from typing import Generator
+
+from kcwarden.auditors.realm.abstract_realm_auditor import AbstractRealmAuditor
+from kcwarden.custom_types.keycloak_object import Realm
+from kcwarden.custom_types.result import Severity, Result
+
+MAX_SSO_SESSION_IDLE_TIMEOUT_SECONDS = 3600
+SSO_SESSION_IDLE_TIMEOUT_HIGH_SECONDS = 28800
+SSO_SESSION_IDLE_TIMEOUT_CRITICAL_SECONDS = 86400
+
+
+class SsoSessionIdleTimeoutExceedsClientSessionIdleTimeout(AbstractRealmAuditor):
+    DEFAULT_SEVERITY = Severity.Medium
+    SHORT_DESCRIPTION = "SSO session idle timeout exceeds client session idle timeout"
+    LONG_DESCRIPTION = (
+        "The SSO session idle timeout is set to more than "
+        f"{MAX_SSO_SESSION_IDLE_TIMEOUT_SECONDS // 60} minutes, but the client session idle timeout "
+        "is either not configured (0) or is not shorter than the SSO session idle timeout, meaning "
+        "clients inherit or exceed the long SSO session idle timeout. "
+        "Setting a dedicated client session idle timeout that is shorter than the SSO session idle "
+        "timeout limits how long individual client sessions remain valid, independently of the SSO session. "
+        "Note that the effective idle timeout (client session idle timeout if set, otherwise SSO session idle timeout) "
+        "also determines the lifetime of refresh tokens."
+    )
+    REFERENCE = "https://www.keycloak.org/docs/latest/server_admin/#_timeouts"
+
+    @staticmethod
+    def _severity_for_sso_idle(sso_idle: int) -> Severity:
+        if sso_idle >= SSO_SESSION_IDLE_TIMEOUT_CRITICAL_SECONDS:
+            return Severity.Critical
+        if sso_idle >= SSO_SESSION_IDLE_TIMEOUT_HIGH_SECONDS:
+            return Severity.High
+        return Severity.Medium
+
+    def audit_realm(self, realm: Realm) -> Generator[Result, None, None]:
+        sso_idle = realm.get_sso_session_idle_timeout()
+        client_idle = realm.get_client_session_idle_timeout()
+        if (sso_idle > MAX_SSO_SESSION_IDLE_TIMEOUT_SECONDS and client_idle == 0) or (
+            client_idle > 0 and client_idle >= sso_idle
+        ):
+            yield self.generate_finding(
+                realm,
+                override_severity=self._severity_for_sso_idle(sso_idle),
+                additional_details={
+                    "sso_session_idle_timeout": sso_idle,
+                    "client_session_idle_timeout": client_idle,
+                },
+            )

--- a/kcwarden/custom_types/keycloak_object.py
+++ b/kcwarden/custom_types/keycloak_object.py
@@ -57,6 +57,14 @@ class Realm(Dataclass):
         """Get access token lifespan in seconds."""
         return self._d["accessTokenLifespan"]
 
+    def get_sso_session_idle_timeout(self) -> int:
+        """Get SSO session idle timeout in seconds."""
+        return self._d["ssoSessionIdleTimeout"]
+
+    def get_client_session_idle_timeout(self) -> int:
+        """Get client session idle timeout in seconds. A value of 0 means it is not set (falls back to SSO session idle timeout)."""
+        return self._d.get("clientSessionIdleTimeout", 0)
+
     def is_offline_session_max_lifespan_enabled(self) -> bool:
         return self._d["offlineSessionMaxLifespanEnabled"]
 
@@ -677,6 +685,13 @@ class Client(Dataclass):
             return int(lifespan_str)
         except ValueError:
             return None
+
+    def get_client_session_idle_timeout_override(self) -> int:
+        """Get client-specific session idle timeout override in seconds. A value of 0 means not set (inherits from realm)."""
+        try:
+            return int(self.get_attributes().get("client.session.idle.timeout", 0))
+        except ValueError:
+            return 0
 
 
 class Group(Dataclass):

--- a/tests/auditors/client/test_client_session_idle_timeout_not_set_while_sso_session_idle_timeout_too_long.py
+++ b/tests/auditors/client/test_client_session_idle_timeout_not_set_while_sso_session_idle_timeout_too_long.py
@@ -1,0 +1,82 @@
+import pytest
+from unittest.mock import Mock
+
+from kcwarden.auditors.client.client_session_idle_timeout_not_set_while_sso_session_idle_timeout_too_long import (
+    ClientSessionIdleTimeoutNotSetWhileSsoSessionIdleTimeoutTooLong,
+)
+
+
+def make_realm(sso_idle, client_idle):
+    realm = Mock()
+    realm.get_sso_session_idle_timeout.return_value = sso_idle
+    realm.get_client_session_idle_timeout.return_value = client_idle
+    return realm
+
+
+class TestClientSessionIdleTimeoutNotSetWhileSsoSessionIdleTimeoutTooLong:
+    @pytest.fixture
+    def auditor(self, database, default_config):
+        auditor_instance = ClientSessionIdleTimeoutNotSetWhileSsoSessionIdleTimeoutTooLong(database, default_config)
+        auditor_instance._DB = Mock()
+        return auditor_instance
+
+    def test_should_consider_only_oidc_clients(self, auditor, mock_client):
+        mock_client.is_oidc_client.return_value = True
+        assert auditor.should_consider_client(mock_client) is True
+
+        mock_client.is_oidc_client.return_value = False
+        assert auditor.should_consider_client(mock_client) is False
+
+    @pytest.mark.parametrize(
+        "sso_idle, realm_client_idle, client_override, expected_finding",
+        [
+            # SSO not exceeding limit, no override — no finding
+            (3600, 0, 0, False),
+            (1800, 0, 0, False),
+            # SSO not exceeding limit, override set but shorter — no finding
+            (1800, 0, 900, False),
+            # SSO not exceeding limit, override >= SSO — finding (general rule, threshold-independent)
+            (1800, 0, 1800, True),  # override equals SSO below threshold — finding
+            (1800, 0, 3600, True),  # override exceeds SSO below threshold — finding
+            # SSO exceeds limit, realm client idle set — no finding (realm already limits it)
+            (7200, 1800, 0, False),
+            # SSO exceeds limit, realm client idle not set, client override shorter — no finding
+            (7200, 0, 1800, False),
+            # SSO exceeds limit, realm client idle not set, client override >= SSO — finding
+            (7200, 0, 7200, True),
+            (7200, 0, 9000, True),
+            # SSO exceeds limit, neither realm nor client override set — finding
+            (3601, 0, 0, True),
+            (7200, 0, 0, True),
+        ],
+    )
+    def test_audit_parametrized(
+        self, auditor, mock_client, sso_idle, realm_client_idle, client_override, expected_finding
+    ):
+        mock_client.get_realm.return_value = make_realm(sso_idle, realm_client_idle)
+        mock_client.get_client_session_idle_timeout_override.return_value = client_override
+        auditor._DB.get_all_clients.return_value = [mock_client]
+
+        results = list(auditor.audit())
+        assert (len(results) == 1) == expected_finding
+
+    def test_finding_contains_additional_details(self, auditor, mock_client):
+        mock_client.get_realm.return_value = make_realm(7200, 0)
+        mock_client.get_client_session_idle_timeout_override.return_value = 0
+        auditor._DB.get_all_clients.return_value = [mock_client]
+
+        results = list(auditor.audit())
+        assert len(results) == 1
+        details = results[0].additional_details
+        assert details["realm_sso_session_idle_timeout"] == 7200
+        assert details["realm_client_session_idle_timeout"] == 0
+        assert details["client_session_idle_timeout_override"] == 0
+
+    def test_non_oidc_client_ignored(self, auditor, mock_client):
+        mock_client.is_oidc_client.return_value = False
+        mock_client.get_realm.return_value = make_realm(7200, 0)
+        mock_client.get_client_session_idle_timeout_override.return_value = 0
+        auditor._DB.get_all_clients.return_value = [mock_client]
+
+        results = list(auditor.audit())
+        assert len(results) == 0

--- a/tests/auditors/realm/test_sso_session_idle_timeout_exceeds_client_session_idle_timeout.py
+++ b/tests/auditors/realm/test_sso_session_idle_timeout_exceeds_client_session_idle_timeout.py
@@ -1,0 +1,73 @@
+import pytest
+
+from kcwarden.auditors.realm.sso_session_idle_timeout_exceeds_client_session_idle_timeout import (
+    SsoSessionIdleTimeoutExceedsClientSessionIdleTimeout,
+)
+from kcwarden.custom_types.result import Severity
+
+
+class TestSsoSessionIdleTimeoutExceedsClientSessionIdleTimeout:
+    @pytest.fixture
+    def auditor(self, mock_database, default_config):
+        return SsoSessionIdleTimeoutExceedsClientSessionIdleTimeout(mock_database, default_config)
+
+    @pytest.mark.parametrize(
+        "sso_idle, client_idle, expected_finding",
+        [
+            # SSO not exceeding limit, client not set — no finding
+            (3600, 0, False),
+            (1800, 0, False),
+            # SSO not exceeding limit, client shorter — no finding
+            (1800, 900, False),
+            # SSO not exceeding limit, client >= SSO — finding (general rule, threshold-independent)
+            (1800, 1800, True),  # client equals SSO below threshold — finding
+            (1800, 3600, True),  # client exceeds SSO below threshold — finding
+            # SSO exceeds limit, client not set — finding
+            (3601, 0, True),
+            (7200, 0, True),
+            # SSO exceeds limit, client set but shorter — no finding
+            (7200, 1800, False),
+            (3601, 3600, False),  # client one second shorter than SSO — no finding
+            # SSO exceeds limit, client set but equal or longer — finding
+            (7200, 7200, True),  # client equals SSO — finding
+            (7200, 9000, True),  # client exceeds SSO — finding
+        ],
+    )
+    def test_audit_parametrized(self, auditor, mock_realm, sso_idle, client_idle, expected_finding):
+        mock_realm.get_sso_session_idle_timeout.return_value = sso_idle
+        mock_realm.get_client_session_idle_timeout.return_value = client_idle
+        auditor._DB.get_all_realms.return_value = [mock_realm]
+
+        results = list(auditor.audit())
+        assert (len(results) == 1) == expected_finding
+
+    @pytest.mark.parametrize(
+        "sso_idle, expected_severity",
+        [
+            (3601, Severity.Medium),  # just above base threshold
+            (28799, Severity.Medium),  # one second below high threshold
+            (28800, Severity.High),  # at high threshold
+            (86399, Severity.High),  # one second below critical threshold
+            (86400, Severity.Critical),  # at critical threshold
+            (172800, Severity.Critical),  # 48h — critical
+        ],
+    )
+    def test_severity_scales_with_sso_idle_timeout(self, auditor, mock_realm, sso_idle, expected_severity):
+        mock_realm.get_sso_session_idle_timeout.return_value = sso_idle
+        mock_realm.get_client_session_idle_timeout.return_value = 0
+        auditor._DB.get_all_realms.return_value = [mock_realm]
+
+        results = list(auditor.audit())
+        assert len(results) == 1
+        assert results[0].severity == expected_severity
+
+    def test_finding_contains_additional_details(self, auditor, mock_realm):
+        mock_realm.get_sso_session_idle_timeout.return_value = 7200
+        mock_realm.get_client_session_idle_timeout.return_value = 0
+        auditor._DB.get_all_realms.return_value = [mock_realm]
+
+        results = list(auditor.audit())
+        assert len(results) == 1
+        details = results[0].additional_details
+        assert details["sso_session_idle_timeout"] == 7200
+        assert details["client_session_idle_timeout"] == 0


### PR DESCRIPTION
Adds two new auditors that check for long SSO session idle timeouts without effective client-level caps.

**Realm auditor** (`SsoSessionIdleTimeoutExceedsClientSessionIdleTimeout`):
Flags a realm when `ssoSessionIdleTimeout` exceeds 1 hour and `clientSessionIdleTimeout` is either not set or is ≥ the SSO timeout — meaning clients inherit the full long lifetime. Severity scales with the SSO timeout value (Medium / High / Critical).

**Client auditor** (`ClientSessionIdleTimeoutNotSetWhileSsoSessionIdleTimeoutTooLong`):
Flags individual OIDC clients that have no client-specific session idle timeout override when the realm already has a long SSO session idle timeout and no realm-level client timeout is configured.

Both auditors also enforce a general rule: a client-related session idle timeout must never be ≥ the realm `ssoSessionIdleTimeout`, regardless of the absolute value — since this determines the effective refresh token lifetime as well.

**AI disclosure:** Implemented with support of 🤖 Claude Code

closes #228 