### PR TITLE
Add Federated JWT as recommended client authentication method

### DIFF
--- a/docs/auditors/clients.md
+++ b/docs/auditors/clients.md
@@ -64,9 +64,10 @@ flow for any client type, public or confidential.
 
 ## ClientAuthenticationViaMTLSOrJWTRecommended
 
-This auditor evaluates whether confidential OIDC clients within Keycloak are using mutual TLS (mTLS) or signed JWTs for client authentication, as opposed to the default _shared client secret_ method.
+This auditor evaluates whether confidential OIDC clients within Keycloak are using Federated JWT, mutual TLS (mTLS), or signed JWTs for client authentication, as opposed to the default _shared client secret_ method.
 Confidential clients are those that can securely hold credentials, making them responsible for authenticating to Keycloak to access its features.
-While using a shared client secret is common, it's recommended to opt for more secure authentication methods such as mTLS or signed JWTs.
+While using a shared client secret is common, it's recommended to opt for more secure authentication methods such as Federated JWT, mTLS, or signed JWTs.
+Federated JWT is currently the most recommended approach, enabling token-based trust relationships via OIDC, SPIFFE/SPIRE, or Kubernetes Service Accounts without long-lived credentials.
 These methods provide enhanced security by ensuring that client credentials are not exposed and are authenticated in a manner that is both secure and verifiable.
 This recommendation aligns with best practices for securing OAuth clients and protecting resource access.
 For more detailed guidance on implementing these recommended authentication methods, refer to the Keycloak documentation.

--- a/kcwarden/auditors/client/client_authentication_via_mtls_or_jwt_recommended.py
+++ b/kcwarden/auditors/client/client_authentication_via_mtls_or_jwt_recommended.py
@@ -2,11 +2,13 @@ from kcwarden.api.auditor import ClientAuditor
 from kcwarden.custom_types.keycloak_object import Client
 from kcwarden.custom_types.result import Severity
 
+STRONG_AUTH_METHODS = {"federated-jwt", "client-jwt", "client-secret-jwt", "client-x509"}
+
 
 class ClientAuthenticationViaMTLSOrJWTRecommended(ClientAuditor):
     DEFAULT_SEVERITY = Severity.Info
-    SHORT_DESCRIPTION = "Client Authentication via mTLS or Signed JWT is Recommended"
-    LONG_DESCRIPTION = "Confidential Clients need to authenticate to Keycloak to use its features. By default, is uses a shared client secret. It is RECOMMENDED to use mTLS or signed JWTs instead, if possible. For details, see the Keycloak documentation: https://www.keycloak.org/docs/latest/server_admin/#_client-credentials"
+    SHORT_DESCRIPTION = "Client Authentication via Federated JWT, mTLS, or Signed JWT is Recommended"
+    LONG_DESCRIPTION = "Confidential Clients need to authenticate to Keycloak to use its features. By default, it uses a shared client secret. It is RECOMMENDED to use Federated JWT, mTLS, or signed JWTs instead, if possible. For details, see the Keycloak documentation: https://www.keycloak.org/docs/latest/server_admin/#_client-credentials"
     REFERENCE = "https://datatracker.ietf.org/doc/html/rfc9700#section-2.5"
 
     def should_consider_client(self, client) -> bool:
@@ -27,11 +29,11 @@ class ClientAuthenticationViaMTLSOrJWTRecommended(ClientAuditor):
 
     @staticmethod
     def client_does_not_use_mtls_or_jwt_auth(client) -> bool:
-        # If the clientAuthenticatorType is client-secret, basic client secret authentication is used.
-        # TODO Check what the correct values for mTLS or signed JWT are, and update this check
-        return client.get_client_authenticator_type() == "client-secret"
+        return client.get_client_authenticator_type() not in STRONG_AUTH_METHODS
 
     def audit_client(self, client: Client):
         if self.client_does_not_use_mtls_or_jwt_auth(client):
             # All clients matching these criteria should be reported
-            yield self.generate_finding(client)
+            yield self.generate_finding(
+                client, additional_details={"client_authenticator_type": client.get_client_authenticator_type()}
+            )

--- a/tests/auditors/client/test_client_authentication_via_mtls_or_jwt_recommended.py
+++ b/tests/auditors/client/test_client_authentication_via_mtls_or_jwt_recommended.py
@@ -31,8 +31,11 @@ class TestClientAuthenticationViaMTLSOrJWTRecommended:
         "client_authenticator_type, should_alert",
         [
             ("client-secret", True),  # Using client-secret, should alert
-            ("jwt", False),  # Using JWT, should not alert
-            ("mtls", False),  # Using mTLS, should not alert
+            ("unknown-method", True),  # Unknown method, should alert
+            ("federated-jwt", False),  # Using Federated JWT, should not alert
+            ("client-jwt", False),  # Using signed JWT, should not alert
+            ("client-secret-jwt", False),  # Using client-secret JWT, should not alert
+            ("client-x509", False),  # Using mTLS (x509), should not alert
         ],
     )
     def test_client_does_not_use_mtls_or_jwt_auth(self, mock_client, auditor, client_authenticator_type, should_alert):
@@ -40,7 +43,7 @@ class TestClientAuthenticationViaMTLSOrJWTRecommended:
         assert auditor.client_does_not_use_mtls_or_jwt_auth(mock_client) == should_alert
 
     def test_audit_function_no_findings(self, confidential_client, auditor):
-        confidential_client.get_client_authenticator_type.return_value = "jwt"
+        confidential_client.get_client_authenticator_type.return_value = "federated-jwt"
         auditor._DB.get_all_clients.return_value = [confidential_client]
         results = list(auditor.audit())
         assert len(results) == 0
@@ -50,10 +53,16 @@ class TestClientAuthenticationViaMTLSOrJWTRecommended:
         auditor._DB.get_all_clients.return_value = [confidential_client]
         results = list(auditor.audit())
         assert len(results) == 1
-        confidential_client.get_client_authenticator_type.assert_called_with()
+        assert results[0].additional_details["client_authenticator_type"] == "client-secret"
 
     def test_audit_function_multiple_clients(self, confidential_client, auditor):
-        confidential_client.get_client_authenticator_type.side_effect = ["client-secret", "jwt", "mtls"]
+        # client-secret is returned twice: once for the check, once for additional_details in generate_finding
+        confidential_client.get_client_authenticator_type.side_effect = [
+            "client-secret",
+            "client-secret",
+            "federated-jwt",
+            "client-x509",
+        ]
         auditor._DB.get_all_clients.return_value = [confidential_client, confidential_client, confidential_client]
         results = list(auditor.audit())
         assert len(results) == 1  # Expect findings from one client


### PR DESCRIPTION
Extends the `ClientAuthenticationViaMTLSOrJWTRecommended` auditor to recognize `federated-jwt`, `client-jwt`, `client-secret-jwt`, and `client-x509` as accepted strong authentication methods, replacing the previous client-secret-only deny-check with an explicit allow-list. Federated JWT is highlighted as the currently most recommended approach.

🤖 Assisted by Claude Code

Closes #229