### PR TITLE
Add support for Keycloak _system client

### DIFF
--- a/kcwarden/api/auditor.py
+++ b/kcwarden/api/auditor.py
@@ -118,7 +118,7 @@ class ClientAuditor(Auditor, ABC):
     """
 
     def should_consider_client(self, client: Client) -> bool:
-        return self.is_not_ignored(client)
+        return self.is_not_ignored(client) and not client.is_system_client()
 
     def audit(self):
         for client in self._DB.get_all_clients():

--- a/kcwarden/custom_types/keycloak_object.py
+++ b/kcwarden/custom_types/keycloak_object.py
@@ -571,6 +571,11 @@ class Client(Dataclass):
             self.get_realm().get_name() == "master" and self.get_name().endswith("-realm") and "protocol" not in self._d
         )
 
+    def is_system_client(self) -> bool:
+        # If "account" client does not exist, Keycloak can create a system client in the realm for certain internal operations
+        # See https://github.com/keycloak/keycloak/blob/main/server-spi-private/src/main/java/org/keycloak/models/utils/SystemClientUtil.java
+        return self.get_name() == "_system"
+
     def get_protocol(self) -> str:
         # Every client should have the "protocol" field set, but the "master-realm"
         # client in the "master" realm for some reason does not include this field.
@@ -578,9 +583,9 @@ class Client(Dataclass):
         try:
             return self._d["protocol"]
         except KeyError:
-            # If the client is a realm-specific client, it for some reason does not
+            # If the client is a realm-specific or system client, it for some reason does not
             # have a "protocol" set. Return openid-connect anyway.
-            if self.is_realm_specific_client():
+            if self.is_realm_specific_client() or self.is_system_client():
                 return "openid-connect"
             # This case should never happen, so instead of blindly returning something,
             # we'd like to know about it. Raise an exception.
@@ -616,6 +621,8 @@ class Client(Dataclass):
 
     def get_client_authenticator_type(self) -> str | None:
         if self.is_public():
+            return None
+        if self.is_system_client():
             return None
         return self._d["clientAuthenticatorType"]
 

--- a/tests/api/test_client_auditor_should_consider_client.py
+++ b/tests/api/test_client_auditor_should_consider_client.py
@@ -20,7 +20,6 @@ class TestClientAuditorShouldConsiderClient:
     @pytest.fixture
     def auditor(self, database, default_config):
         auditor_instance = ConcreteClientAuditor(database, default_config)
-        auditor_instance._DB = Mock()
         auditor_instance.is_not_ignored = Mock(return_value=True)
         return auditor_instance
 

--- a/tests/api/test_client_auditor_should_consider_client.py
+++ b/tests/api/test_client_auditor_should_consider_client.py
@@ -1,0 +1,69 @@
+import pytest
+from unittest.mock import Mock
+
+from kcwarden.api.auditor import ClientAuditor
+from kcwarden.custom_types.config_keys import AUDITOR_CONFIG
+from kcwarden.custom_types.result import Severity
+
+
+class ConcreteClientAuditor(ClientAuditor):
+    DEFAULT_SEVERITY = Severity.Medium
+    SHORT_DESCRIPTION = "test"
+    LONG_DESCRIPTION = "test"
+    REFERENCE = "test"
+
+    def audit_client(self, client):
+        yield from []
+
+
+class TestClientAuditorShouldConsiderClient:
+    @pytest.fixture
+    def auditor(self, database, default_config):
+        auditor_instance = ConcreteClientAuditor(database, default_config)
+        auditor_instance._DB = Mock()
+        auditor_instance.is_not_ignored = Mock(return_value=True)
+        return auditor_instance
+
+    def test_should_consider_normal_client(self, mock_client, auditor):
+        mock_client.is_system_client.return_value = False
+        assert auditor.should_consider_client(mock_client) is True
+
+    def test_should_consider_system_client_returns_false(self, mock_client, auditor):
+        # Keycloak internal _system client should always be skipped
+        mock_client.is_system_client.return_value = True
+        assert auditor.should_consider_client(mock_client) is False
+
+    def test_should_consider_ignored_client_returns_false(self, mock_client, auditor):
+        auditor.is_not_ignored.return_value = False
+        mock_client.is_system_client.return_value = False
+        assert auditor.should_consider_client(mock_client) is False
+
+
+class TestClientAuditorIsNotIgnored:
+    """Tests for the real is_not_ignored implementation (ignore list via config)."""
+
+    @pytest.fixture
+    def auditor_with_ignore_list(self, database):
+        config = {AUDITOR_CONFIG: {"ConcreteClientAuditor": ["ignored-client", "ignored-regex-.*"]}}
+        return ConcreteClientAuditor(database, config)
+
+    @pytest.fixture
+    def auditor_empty_ignore_list(self, database):
+        config = {AUDITOR_CONFIG: {"ConcreteClientAuditor": []}}
+        return ConcreteClientAuditor(database, config)
+
+    def test_client_not_in_ignore_list_is_not_ignored(self, mock_client, auditor_empty_ignore_list):
+        mock_client.get_name.return_value = "some-client"
+        assert auditor_empty_ignore_list.should_consider_client(mock_client) is True
+
+    def test_client_exact_match_in_ignore_list_is_ignored(self, mock_client, auditor_with_ignore_list):
+        mock_client.get_name.return_value = "ignored-client"
+        assert auditor_with_ignore_list.should_consider_client(mock_client) is False
+
+    def test_client_regex_match_in_ignore_list_is_ignored(self, mock_client, auditor_with_ignore_list):
+        mock_client.get_name.return_value = "ignored-regex-something"
+        assert auditor_with_ignore_list.should_consider_client(mock_client) is False
+
+    def test_client_unrelated_name_is_not_ignored(self, mock_client, auditor_with_ignore_list):
+        mock_client.get_name.return_value = "regular-client"
+        assert auditor_with_ignore_list.should_consider_client(mock_client) is True

--- a/tests/auditors/client/test_client_access_token_lifespan_too_long.py
+++ b/tests/auditors/client/test_client_access_token_lifespan_too_long.py
@@ -95,27 +95,32 @@ class TestClientAccessTokenLifespanTooLong:
         client1.get_access_token_lifespan_override.return_value = None  # No override - OK
         client1.get_realm.return_value = mock_realm
         client1.is_oidc_client.return_value = True
+        client1.is_system_client.return_value = False
 
         client2 = Mock()
         client2.get_access_token_lifespan_override.return_value = 300  # 5 minutes - OK
         client2.get_realm.return_value = mock_realm
         client2.is_oidc_client.return_value = True
+        client2.is_system_client.return_value = False
 
         client3 = Mock()
         client3.get_access_token_lifespan_override.return_value = 1800  # 30 minutes - Too long
         client3.get_realm.return_value = mock_realm
         client3.is_oidc_client.return_value = True
+        client3.is_system_client.return_value = False
 
         client4 = Mock()
         client4.get_access_token_lifespan_override.return_value = 900  # 15 minutes - Too long
         client4.get_realm.return_value = mock_realm
         client4.is_oidc_client.return_value = True
+        client4.is_system_client.return_value = False
 
         # client5 is not an OIDC client - should be ignored
         client5 = Mock()
         client5.get_access_token_lifespan_override.return_value = 1800  # 30 minutes but ignored
         client5.get_realm.return_value = mock_realm
         client5.is_oidc_client.return_value = False
+        client5.is_system_client.return_value = False
 
         auditor._DB.get_all_clients.return_value = [client1, client2, client3, client4, client5]
         results = list(auditor.audit())

--- a/tests/auditors/client/test_client_with_default_offline_access_scope.py
+++ b/tests/auditors/client/test_client_with_default_offline_access_scope.py
@@ -80,6 +80,7 @@ class TestClientWithDefaultOfflineAccessScope:
         client1.use_refresh_tokens.return_value = True
         client1.is_public.return_value = False
         client1.is_realm_specific_client.return_value = False
+        client1.is_system_client.return_value = False
 
         client2 = Mock()
         client2.get_default_client_scopes.return_value = []
@@ -91,6 +92,7 @@ class TestClientWithDefaultOfflineAccessScope:
         client2.is_public.return_value = True
         client2.allows_user_authentication.return_value = True
         client2.is_realm_specific_client.return_value = False
+        client2.is_system_client.return_value = False
 
         client3 = Mock()
         client3.get_default_client_scopes.return_value = ["offline_access"]
@@ -102,6 +104,7 @@ class TestClientWithDefaultOfflineAccessScope:
         client3.is_public.return_value = False
         client3.allows_user_authentication.return_value = True
         client3.is_realm_specific_client.return_value = False
+        client3.is_system_client.return_value = False
 
         auditor._DB.get_all_clients.return_value = [client1, client2, client3]
         results = list(auditor.audit())

--- a/tests/auditors/client/test_client_with_full_scope_allowed.py
+++ b/tests/auditors/client/test_client_with_full_scope_allowed.py
@@ -59,18 +59,21 @@ class TestClientWithFullScopeAllowed:
         client1.get_default_client_scopes.return_value = ["email"]
         client1.get_optional_client_scopes.return_value = ["profile"]
         client1.is_realm_specific_client.return_value = False
+        client1.is_system_client.return_value = False
 
         client2 = Mock()
         client2.has_full_scope_allowed.return_value = False
         client2.get_default_client_scopes.return_value = ["email", "profile"]
         client2.get_optional_client_scopes.return_value = ["address"]
         client2.is_realm_specific_client.return_value = False
+        client2.is_system_client.return_value = False
 
         client3 = Mock()
         client3.has_full_scope_allowed.return_value = True
         client3.get_default_client_scopes.return_value = ["offline_access"]
         client3.get_optional_client_scopes.return_value = []
         client3.is_realm_specific_client.return_value = False
+        client3.is_system_client.return_value = False
 
         auditor._DB.get_all_clients.return_value = [client1, client2, client3]
         results = list(auditor.audit())

--- a/tests/auditors/client/test_client_with_optional_offline_access_scope.py
+++ b/tests/auditors/client/test_client_with_optional_offline_access_scope.py
@@ -77,6 +77,7 @@ class TestClientWithOptionalOfflineAccessScope:
         client1.use_refresh_tokens.return_value = True
         client1.is_public.return_value = False
         client1.is_realm_specific_client.return_value = False
+        client1.is_system_client.return_value = False
 
         client2 = Mock()
         client2.get_optional_client_scopes.return_value = []
@@ -87,6 +88,7 @@ class TestClientWithOptionalOfflineAccessScope:
         client2.use_refresh_tokens.return_value = False
         client2.is_public.return_value = True
         client2.is_realm_specific_client.return_value = False
+        client2.is_system_client.return_value = False
 
         client3 = Mock()
         client3.get_optional_client_scopes.return_value = ["offline_access"]
@@ -97,6 +99,7 @@ class TestClientWithOptionalOfflineAccessScope:
         client3.use_refresh_tokens.return_value = True
         client3.is_public.return_value = False
         client3.is_realm_specific_client.return_value = False
+        client3.is_system_client.return_value = False
 
         auditor._DB.get_all_clients.return_value = [client1, client2, client3]
         results = list(auditor.audit())

--- a/tests/auditors/client/test_client_with_service_account_and_other_flow_enabled.py
+++ b/tests/auditors/client/test_client_with_service_account_and_other_flow_enabled.py
@@ -91,6 +91,7 @@ class TestClientWithServiceAccountAndOtherFlowEnabled:
         client1.has_standard_flow_enabled.return_value = True
         client1.allows_user_authentication.return_value = True
         client1.is_realm_specific_client.return_value = False
+        client1.is_system_client.return_value = False
 
         client2 = Mock()
         client2.is_oidc_client.return_value = True
@@ -102,6 +103,7 @@ class TestClientWithServiceAccountAndOtherFlowEnabled:
         client2.has_standard_flow_enabled.return_value = False
         client2.allows_user_authentication.return_value = False
         client2.is_realm_specific_client.return_value = False
+        client2.is_system_client.return_value = False
 
         client3 = Mock()
         client3.is_oidc_client.return_value = True
@@ -113,6 +115,7 @@ class TestClientWithServiceAccountAndOtherFlowEnabled:
         client3.has_device_authorization_grant_flow_enabled.return_value = False
         client3.allows_user_authentication.return_value = True
         client3.is_realm_specific_client.return_value = False
+        client3.is_system_client.return_value = False
 
         auditor._DB.get_all_clients.return_value = [client1, client2, client3]
         results = list(auditor.audit())

--- a/tests/auditors/client/test_saml_client_erroneously_configured_wildcard_uri.py
+++ b/tests/auditors/client/test_saml_client_erroneously_configured_wildcard_uri.py
@@ -61,6 +61,7 @@ class TestSamlClientHasErroneouslyConfiguredWildcardURI:
         client_safe.__str__ = Mock(return_value="safe-saml")
         client_safe.is_saml_client.return_value = True
         client_safe.get_resolved_redirect_uris.return_value = ["https://example.com/*"]
+        client_safe.is_system_client.return_value = False
 
         # Vulnerable SAML client — wildcard in domain
         client_vuln = Mock()
@@ -68,6 +69,7 @@ class TestSamlClientHasErroneouslyConfiguredWildcardURI:
         client_vuln.__str__ = Mock(return_value="vuln-saml")
         client_vuln.is_saml_client.return_value = True
         client_vuln.get_resolved_redirect_uris.return_value = ["https://example.com*"]
+        client_vuln.is_system_client.return_value = False
 
         # OIDC client — should be ignored regardless of URI
         client_oidc = Mock()
@@ -75,6 +77,7 @@ class TestSamlClientHasErroneouslyConfiguredWildcardURI:
         client_oidc.__str__ = Mock(return_value="oidc-client")
         client_oidc.is_saml_client.return_value = False
         client_oidc.get_resolved_redirect_uris.return_value = ["https://example.com*"]
+        client_oidc.is_system_client.return_value = False
 
         auditor._DB.get_all_clients.return_value = [client_safe, client_vuln, client_oidc]
 
@@ -89,6 +92,7 @@ class TestSamlClientHasErroneouslyConfiguredWildcardURI:
         client_multi.name = "multi-bad"
         client_multi.__str__ = Mock(return_value="multi-bad")
         client_multi.is_saml_client.return_value = True
+        client_multi.is_system_client.return_value = False
         client_multi.get_resolved_redirect_uris.return_value = [
             "https://ok.com/*",
             "https://bad.com*",

--- a/tests/auditors/client/test_saml_client_should_not_use_wildcard_redirect_uri.py
+++ b/tests/auditors/client/test_saml_client_should_not_use_wildcard_redirect_uri.py
@@ -52,18 +52,21 @@ class TestSamlClientShouldNotUseWildcardRedirectURI:
         client_safe.name = "safe-saml"
         client_safe.__str__ = Mock(return_value="safe-saml")
         client_safe.is_saml_client.return_value = True
+        client_safe.is_system_client.return_value = False
         client_safe.get_resolved_redirect_uris.return_value = ["https://ok.com"]
 
         client_vuln = Mock()
         client_vuln.name = "vuln-saml"
         client_vuln.__str__ = Mock(return_value="vuln-saml")
         client_vuln.is_saml_client.return_value = True
+        client_vuln.is_system_client.return_value = False
         client_vuln.get_resolved_redirect_uris.return_value = ["https://bad.com/*"]
 
         client_oidc = Mock()
         client_oidc.name = "oidc-client"
         client_oidc.__str__ = Mock(return_value="oidc-client")
         client_oidc.is_saml_client.return_value = False
+        client_oidc.is_system_client.return_value = False
         client_oidc.get_resolved_redirect_uris.return_value = ["https://bad-oidc.com/*"]
 
         auditor._DB.get_all_clients.return_value = [client_safe, client_vuln, client_oidc]
@@ -79,6 +82,7 @@ class TestSamlClientShouldNotUseWildcardRedirectURI:
         client_multi.name = "multi-bad"
         client_multi.__str__ = Mock(return_value="multi-bad")
         client_multi.is_saml_client.return_value = True
+        client_multi.is_system_client.return_value = False
         client_multi.get_resolved_redirect_uris.return_value = [
             "https://ok.com",
             "https://bad.com/*",

--- a/tests/auditors/client/test_saml_client_with_assertion_signature_disabled.py
+++ b/tests/auditors/client/test_saml_client_with_assertion_signature_disabled.py
@@ -48,6 +48,7 @@ class TestSamlClientWithAssertionSignatureDisabled:
         client_secure.__str__ = Mock(return_value="secure-client")
         client_secure.is_saml_client.return_value = True
         client_secure.get_saml_assertion_signature.return_value = True
+        client_secure.is_system_client.return_value = False
 
         # 2. Vulnerable SAML Client
         client_vuln = Mock()
@@ -56,6 +57,7 @@ class TestSamlClientWithAssertionSignatureDisabled:
         client_vuln.__str__ = Mock(return_value="vuln-client")
         client_vuln.is_saml_client.return_value = True
         client_vuln.get_saml_assertion_signature.return_value = False
+        client_vuln.is_system_client.return_value = False
 
         # 3. OIDC Client
         client_oidc = Mock()
@@ -64,6 +66,7 @@ class TestSamlClientWithAssertionSignatureDisabled:
         client_oidc.__str__ = Mock(return_value="oidc-client")
         client_oidc.is_saml_client.return_value = False
         client_oidc.get_saml_assertion_signature.return_value = False
+        client_oidc.is_system_client.return_value = False
 
         auditor._DB.get_all_clients.return_value = [client_secure, client_vuln, client_oidc]
 

--- a/tests/auditors/client/test_saml_client_with_client_signature_disabled.py
+++ b/tests/auditors/client/test_saml_client_with_client_signature_disabled.py
@@ -45,18 +45,21 @@ class TestSamlClientWithClientSignatureDisabled:
         client_oidc.__str__ = Mock(return_value="oidc-client")
         client_oidc.is_saml_client.return_value = False
         client_oidc.is_saml_client_signature_required.return_value = False
+        client_oidc.is_system_client.return_value = False
 
         client_secure = Mock()
         client_secure.name = "secure-saml"
         client_secure.__str__ = Mock(return_value="secure-saml")
         client_secure.is_saml_client.return_value = True
         client_secure.is_saml_client_signature_required.return_value = True
+        client_secure.is_system_client.return_value = False
 
         client_vuln = Mock()
         client_vuln.name = "vuln-saml"
         client_vuln.__str__ = Mock(return_value="vuln-saml")
         client_vuln.is_saml_client.return_value = True
         client_vuln.is_saml_client_signature_required.return_value = False
+        client_vuln.is_system_client.return_value = False
 
         auditor._DB.get_all_clients.return_value = [client_oidc, client_secure, client_vuln]
 

--- a/tests/auditors/client/test_saml_client_with_encryption_disabled.py
+++ b/tests/auditors/client/test_saml_client_with_encryption_disabled.py
@@ -43,18 +43,21 @@ class TestSamlClientWithEncryptionDisabled:
         client_secure.__str__ = Mock(return_value="secure-saml")
         client_secure.is_saml_client.return_value = True
         client_secure.is_saml_encryption_enabled.return_value = True
+        client_secure.is_system_client.return_value = False
 
         client_vuln = Mock()
         client_vuln.name = "vuln-saml"
         client_vuln.__str__ = Mock(return_value="vuln-saml")
         client_vuln.is_saml_client.return_value = True
         client_vuln.is_saml_encryption_enabled.return_value = False
+        client_vuln.is_system_client.return_value = False
 
         client_oidc = Mock()
         client_oidc.name = "oidc-client"
         client_oidc.__str__ = Mock(return_value="oidc-client")
         client_oidc.is_saml_client.return_value = False
         client_oidc.is_saml_encryption_enabled.return_value = False
+        client_oidc.is_system_client.return_value = False
 
         auditor._DB.get_all_clients.return_value = [client_secure, client_vuln, client_oidc]
 

--- a/tests/auditors/client/test_saml_client_with_weak_signature_algorithm.py
+++ b/tests/auditors/client/test_saml_client_with_weak_signature_algorithm.py
@@ -53,18 +53,21 @@ class TestSamlClientWithWeakSignatureAlgorithm:
         client_oidc.__str__ = Mock(return_value="oidc")
         client_oidc.is_saml_client.return_value = False
         client_oidc.get_saml_signature_algorithm.return_value = "RSA_SHA1"
+        client_oidc.is_system_client.return_value = False
 
         client_strong = Mock()
         client_strong.name = "strong"
         client_strong.__str__ = Mock(return_value="strong")
         client_strong.is_saml_client.return_value = True
         client_strong.get_saml_signature_algorithm.return_value = "RSA_SHA256"
+        client_strong.is_system_client.return_value = False
 
         client_weak = Mock()
         client_weak.name = "weak"
         client_weak.__str__ = Mock(return_value="weak")
         client_weak.is_saml_client.return_value = True
         client_weak.get_saml_signature_algorithm.return_value = "RSA_SHA1"
+        client_weak.is_system_client.return_value = False
 
         auditor._DB.get_all_clients.return_value = [client_oidc, client_strong, client_weak]
 

--- a/tests/auditors/client/test_saml_client_without_onetimeuse_condition.py
+++ b/tests/auditors/client/test_saml_client_without_onetimeuse_condition.py
@@ -43,18 +43,21 @@ class TestSamlClientWithoutOneTimeUseCondition:
         client_secure.__str__ = Mock(return_value="secure-saml")
         client_secure.is_saml_client.return_value = True
         client_secure.is_saml_onetimeuse_condition_enabled.return_value = True
+        client_secure.is_system_client.return_value = False
 
         client_vuln = Mock()
         client_vuln.name = "vuln-saml"
         client_vuln.__str__ = Mock(return_value="vuln-saml")
         client_vuln.is_saml_client.return_value = True
         client_vuln.is_saml_onetimeuse_condition_enabled.return_value = False
+        client_vuln.is_system_client.return_value = False
 
         client_oidc = Mock()
         client_oidc.name = "oidc-client"
         client_oidc.__str__ = Mock(return_value="oidc-client")
         client_oidc.is_saml_client.return_value = False
         client_oidc.is_saml_onetimeuse_condition_enabled.return_value = False
+        client_oidc.is_system_client.return_value = False
 
         auditor._DB.get_all_clients.return_value = [client_secure, client_vuln, client_oidc]
 

--- a/tests/auditors/client/test_using_nondefault_user_attributes_in_clients_without_user_profiles_feature_is_dangerous.py
+++ b/tests/auditors/client/test_using_nondefault_user_attributes_in_clients_without_user_profiles_feature_is_dangerous.py
@@ -103,6 +103,7 @@ class TestUsingNonDefaultUserAttributesInClientsWithoutUserProfilesFeatureIsDang
     def test_audit_function_multiple_clients(self, auditor):
         # Create separate mock clients with distinct settings
         client1 = Mock()
+        client1.is_system_client.return_value = False
         realm1: Realm = Mock()
         realm1.get_unmanaged_attribute_policy.return_value = "ENABLED"
         client1.get_realm.return_value = realm1
@@ -112,6 +113,7 @@ class TestUsingNonDefaultUserAttributesInClientsWithoutUserProfilesFeatureIsDang
         client1.get_protocol_mappers.return_value = [mapper1]
 
         client2 = Mock()
+        client2.is_system_client.return_value = False
         realm2 = Mock()
         realm2.get_unmanaged_attribute_policy.return_value = "ADMIN_EDIT"
         client2.get_realm.return_value = realm2

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -172,6 +172,7 @@ def mock_client(mock_realm):
     client.get_default_client_scopes.return_value = []
     client.get_optional_client_scopes.return_value = []
     client.is_oidc_client.return_value = True
+    client.is_system_client.return_value = False
     client.is_default_keycloak_client.return_value = False
     client.is_realm_specific_client.return_value = False
     client.get_protocol_mappers.return_value = []

--- a/tests/custom_types/test_keycloak_object.py
+++ b/tests/custom_types/test_keycloak_object.py
@@ -61,6 +61,7 @@ class TestClient:
         client = Client(
             {
                 "clientId": "_system",
+                "publicClient": False,
                 "attributes": {},
             },
             [],

--- a/tests/custom_types/test_keycloak_object.py
+++ b/tests/custom_types/test_keycloak_object.py
@@ -26,6 +26,49 @@ class TestClient:
         )
         assert client.use_refresh_tokens() == expected
 
+    @pytest.mark.parametrize(
+        ["client_id", "expected"],
+        [
+            ("_system", True),
+            ("some-other-client", False),
+        ],
+    )
+    def test_is_system_client(self, client_id: str, expected: bool):
+        client = Client(
+            {
+                "clientId": client_id,
+                "attributes": {},
+            },
+            [],
+            {},
+            realm=Mock(),
+        )
+        assert client.is_system_client() == expected
+
+    def test_get_protocol_returns_openid_connect_for_system_client(self):
+        client = Client(
+            {
+                "clientId": "_system",
+                "attributes": {},
+            },
+            [],
+            {},
+            realm=Mock(),
+        )
+        assert client.get_protocol() == "openid-connect"
+
+    def test_get_client_authenticator_type_returns_none_for_system_client(self):
+        client = Client(
+            {
+                "clientId": "_system",
+                "attributes": {},
+            },
+            [],
+            {},
+            realm=Mock(),
+        )
+        assert client.get_client_authenticator_type() is None
+
 
 class TestRealm:
     def test_extract_password_policy_empty(self):


### PR DESCRIPTION
### Summary

- Fix for bug https://github.com/iteratec/kcwarden/issues/122
- If realm has no 'account' client, Keycloak creates an internal system client to the realm
  - See https://github.com/keycloak/keycloak/blob/main/server-spi-private/src/main/java/org/keycloak/models/utils/SystemClientUtil.java#L36
- When kcwarden scans the realm configuration, it screams about missing protocol for the client
- This PR makes changes to allow scanning a realm configuration with a Keycloak system client, by returning fake:
  - Protocol
  - Client authenticator type
  
### Notes
**NOTE:** Did not write any tests. I am happy to write tests, if I can get some hints on what kind of tests would be useful for this specific case.
  
**NOTE 2:** Would it be even better to completely skip auditing the system client, since some medium-level warnings are raised (which can not really be fixed):
 - ClientHasNoRedirectUris
 - ConfidentialClientShouldEnforcePKCE
 
 ### Example
[realm_system_client_example.json](https://github.com/user-attachments/files/26931659/realm_system_client_example.json) (simplified, other crud redacted)
