### PR TITLE
Bug: Fix unintended state mutation in group role inheritance logic

### DIFF
--- a/kcwarden/custom_types/keycloak_object.py
+++ b/kcwarden/custom_types/keycloak_object.py
@@ -782,11 +782,8 @@ class Group(Dataclass):
             return deepcopy(self._d["clientRoles"])
         parent_client_roles = self._parent.get_effective_client_roles()
         my_client_roles = self.get_client_roles()
-        for client in my_client_roles.keys():
-            if client in parent_client_roles:
-                parent_client_roles[client] += my_client_roles[client]
-            else:
-                parent_client_roles[client] = my_client_roles[client]
+        for client, roles in my_client_roles.items():
+            parent_client_roles.setdefault(client, []).extend(roles)
         return parent_client_roles
 
     def has_subgroups(self) -> bool:

--- a/tests/custom_types/test_keycloak_object.py
+++ b/tests/custom_types/test_keycloak_object.py
@@ -2,7 +2,7 @@ from unittest.mock import Mock
 
 import pytest
 
-from kcwarden.custom_types.keycloak_object import Client, Realm
+from kcwarden.custom_types.keycloak_object import Client, Group, Realm
 
 
 class TestClient:
@@ -69,3 +69,109 @@ class TestRealm:
         # Test getting iterations from password policy
         realm = Realm({})
         assert realm.get_password_hash_iterations() is None
+
+
+class TestGroup:
+    def test_get_effective_client_roles_does_not_mutate_intermediate_group(self):
+        realm = Mock()
+        grandparent_raw = {
+            "name": "grandparent",
+            "path": "/grandparent",
+            "attributes": {},
+            "realmRoles": [],
+            "clientRoles": {"client-a": ["gp-role"]},
+            "subGroups": [],
+        }
+        parent_raw = {
+            "name": "parent",
+            "path": "/grandparent/parent",
+            "attributes": {},
+            "realmRoles": [],
+            "clientRoles": {"client-b": ["parent-role"]},
+            "subGroups": [],
+        }
+        child_raw = {
+            "name": "child",
+            "path": "/grandparent/parent/child",
+            "attributes": {},
+            "realmRoles": [],
+            "clientRoles": {"client-b": ["child-role"]},
+            "subGroups": [],
+        }
+
+        grandparent_group = Group(grandparent_raw, realm)
+        parent_group = Group(parent_raw, realm, grandparent_group)
+        child_group = Group(child_raw, realm, parent_group)
+
+        effective_roles = child_group.get_effective_client_roles()
+
+        assert effective_roles == {
+            "client-a": ["gp-role"],
+            "client-b": ["parent-role", "child-role"],
+        }
+        assert parent_raw["clientRoles"] == {"client-b": ["parent-role"]}
+
+    def test_get_effective_client_roles_does_not_mutate_source_groups(self):
+        realm = Mock()
+        parent_raw = {
+            "name": "parent",
+            "path": "/parent",
+            "attributes": {},
+            "realmRoles": [],
+            "clientRoles": {"client-a": ["role-parent"]},
+            "subGroups": [],
+        }
+        child_raw = {
+            "name": "child",
+            "path": "/parent/child",
+            "attributes": {},
+            "realmRoles": [],
+            "clientRoles": {"client-a": ["role-child"], "client-b": ["role-child-only"]},
+            "subGroups": [],
+        }
+
+        parent_group = Group(parent_raw, realm)
+        child_group = Group(child_raw, realm, parent_group)
+
+        effective_roles = child_group.get_effective_client_roles()
+
+        assert effective_roles == {
+            "client-a": ["role-parent", "role-child"],
+            "client-b": ["role-child-only"],
+        }
+        assert parent_raw["clientRoles"] == {"client-a": ["role-parent"]}
+        assert child_raw["clientRoles"] == {
+            "client-a": ["role-child"],
+            "client-b": ["role-child-only"],
+        }
+
+    def test_get_effective_client_roles_is_stable_across_calls(self):
+        realm = Mock()
+        parent_group = Group(
+            {
+                "name": "parent",
+                "path": "/parent",
+                "attributes": {},
+                "realmRoles": [],
+                "clientRoles": {"client-a": ["role-parent"]},
+                "subGroups": [],
+            },
+            realm,
+        )
+        child_group = Group(
+            {
+                "name": "child",
+                "path": "/parent/child",
+                "attributes": {},
+                "realmRoles": [],
+                "clientRoles": {"client-a": ["role-child"]},
+                "subGroups": [],
+            },
+            realm,
+            parent_group,
+        )
+
+        first_result = child_group.get_effective_client_roles()
+        second_result = child_group.get_effective_client_roles()
+
+        assert first_result == second_result == {"client-a": ["role-parent", "role-child"]}


### PR DESCRIPTION
This change fixes unintended state mutation in group role inheritance logic for client roles.

In `keycloak_object.py`, `Group.get_effective_client_roles` previously could mutate role lists owned by ancestor/intermediate groups while traversing the hierarchy.  
The method now merges roles without reusing list references from child objects.

#### Bug
The previous implementation mixed two behaviors that caused aliasing:

1. When a client key was missing in the accumulated result, it assigned the child list object directly.
2. In deeper levels, later merges used in-place list growth on that same referenced list.

In a 3-level hierarchy (grandparent -> parent -> child), this could mutate parent raw data while computing child effective roles. That means a read-style traversal had side effects on source objects.

#### Fix
The merge logic now uses a safe accumulator pattern:

1. Iterate with client and roles directly.
2. Ensure a local list exists in the accumulator via setdefault.
3. Copy role values into that local list using extend.

This preserves the expected result while avoiding shared list references and side effects.

#### Tests
Added and kept focused regression coverage in test_keycloak_object.py:

1. `test_get_effective_client_roles_does_not_mutate_intermediate_group`  
   Validates the 3-level hierarchy case that exposed the bug.
2. `test_get_effective_client_roles_does_not_mutate_source_groups`  
   Confirms no mutation in the simpler parent-child case.
3. `test_get_effective_client_roles_is_stable_across_calls`  
   Confirms repeat calls return stable results.

#### Impact
- No intended functional change to effective role contents.
- Prevents hidden mutations of input structures.
- Makes hierarchy traversal behavior deterministic and side-effect free.

**AI Disclosure:** Found and fixed using GitHub Copilot.