### PR TITLE
Change group index to path instead of name

### DIFF
--- a/kcwarden/database/in_memory_db.py
+++ b/kcwarden/database/in_memory_db.py
@@ -36,7 +36,7 @@ class InMemoryDatabase(Database):
         self.SERVICE_ACCOUNTS[saccount.get_username()] = saccount
 
     def add_group(self, group: Group):
-        self.GROUPS[group.get_name()] = group
+        self.GROUPS[group.get_path()] = group
 
     def add_realm_role(self, role: RealmRole):
         self.REALM_ROLES[role.get_name()] = role


### PR DESCRIPTION
Right now, groups are indexed by name, not path. This can lead to conflicts for subgroups. This PR changes the behavior to use the path instead of the name. `get_group` is currently not called anywhere in the codebase, so there are no further changes necessary.

Fixes #260