### PR TITLE
Refactor SAML client unit tests to consistently use test fixtures

### DIFF
--- a/tests/auditors/client/test_saml_client_erroneously_configured_wildcard_uri.py
+++ b/tests/auditors/client/test_saml_client_erroneously_configured_wildcard_uri.py
@@ -54,45 +54,29 @@ class TestSamlClientHasErroneouslyConfiguredWildcardURI:
         if expected_finding:
             assert results[0].additional_details["redirect_uri"] == uri
 
-    def test_audit_mixed_clients(self, auditor):
+    def test_audit_mixed_clients(self, auditor, create_mock_client):
         # Safe SAML client — wildcard only in path
-        client_safe = Mock()
-        client_safe.name = "safe-saml"
-        client_safe.__str__ = Mock(return_value="safe-saml")
-        client_safe.is_saml_client.return_value = True
+        client_safe = create_mock_client(name="safe-saml", is_saml_client=True)
         client_safe.get_resolved_redirect_uris.return_value = ["https://example.com/*"]
-        client_safe.is_system_client.return_value = False
 
         # Vulnerable SAML client — wildcard in domain
-        client_vuln = Mock()
-        client_vuln.name = "vuln-saml"
-        client_vuln.__str__ = Mock(return_value="vuln-saml")
-        client_vuln.is_saml_client.return_value = True
+        client_vuln = create_mock_client(name="vuln-saml", is_saml_client=True)
         client_vuln.get_resolved_redirect_uris.return_value = ["https://example.com*"]
-        client_vuln.is_system_client.return_value = False
 
         # OIDC client — should be ignored regardless of URI
-        client_oidc = Mock()
-        client_oidc.name = "oidc-client"
-        client_oidc.__str__ = Mock(return_value="oidc-client")
-        client_oidc.is_saml_client.return_value = False
+        client_oidc = create_mock_client(name="oidc-client", is_saml_client=False)
         client_oidc.get_resolved_redirect_uris.return_value = ["https://example.com*"]
-        client_oidc.is_system_client.return_value = False
 
         auditor._DB.get_all_clients.return_value = [client_safe, client_vuln, client_oidc]
 
         results = list(auditor.audit())
 
         assert len(results) == 1
-        assert results[0]._offending_object.name == "vuln-saml"
+        assert results[0]._offending_object.get_name() == "vuln-saml"
         assert results[0].additional_details["redirect_uri"] == "https://example.com*"
 
-    def test_audit_multiple_bad_uris(self, auditor):
-        client_multi = Mock()
-        client_multi.name = "multi-bad"
-        client_multi.__str__ = Mock(return_value="multi-bad")
-        client_multi.is_saml_client.return_value = True
-        client_multi.is_system_client.return_value = False
+    def test_audit_multiple_bad_uris(self, auditor, create_mock_client):
+        client_multi = create_mock_client(name="multi-bad", is_saml_client=True)
         client_multi.get_resolved_redirect_uris.return_value = [
             "https://ok.com/*",
             "https://bad.com*",

--- a/tests/auditors/client/test_saml_client_should_not_use_wildcard_redirect_uri.py
+++ b/tests/auditors/client/test_saml_client_should_not_use_wildcard_redirect_uri.py
@@ -47,26 +47,14 @@ class TestSamlClientShouldNotUseWildcardRedirectURI:
         bad_uris = auditor.get_vulnerable_uris(mock_client)
         assert bad_uris == expected_findings
 
-    def test_audit_function_mixed_clients(self, auditor):
-        client_safe = Mock()
-        client_safe.name = "safe-saml"
-        client_safe.__str__ = Mock(return_value="safe-saml")
-        client_safe.is_saml_client.return_value = True
-        client_safe.is_system_client.return_value = False
+    def test_audit_function_mixed_clients(self, auditor, create_mock_client):
+        client_safe = create_mock_client(name="safe-saml", is_saml_client=True)
         client_safe.get_resolved_redirect_uris.return_value = ["https://ok.com"]
 
-        client_vuln = Mock()
-        client_vuln.name = "vuln-saml"
-        client_vuln.__str__ = Mock(return_value="vuln-saml")
-        client_vuln.is_saml_client.return_value = True
-        client_vuln.is_system_client.return_value = False
+        client_vuln = create_mock_client(name="vuln-saml", is_saml_client=True)
         client_vuln.get_resolved_redirect_uris.return_value = ["https://bad.com/*"]
 
-        client_oidc = Mock()
-        client_oidc.name = "oidc-client"
-        client_oidc.__str__ = Mock(return_value="oidc-client")
-        client_oidc.is_saml_client.return_value = False
-        client_oidc.is_system_client.return_value = False
+        client_oidc = create_mock_client(name="oidc-client", is_saml_client=False)
         client_oidc.get_resolved_redirect_uris.return_value = ["https://bad-oidc.com/*"]
 
         auditor._DB.get_all_clients.return_value = [client_safe, client_vuln, client_oidc]
@@ -74,15 +62,11 @@ class TestSamlClientShouldNotUseWildcardRedirectURI:
         results = list(auditor.audit())
 
         assert len(results) == 1
-        assert results[0]._offending_object.name == "vuln-saml"
+        assert results[0]._offending_object.get_name() == "vuln-saml"
         assert results[0].additional_details["redirect_uri"] == "https://bad.com/*"
 
-    def test_audit_function_multiple_bad_uris(self, auditor):
-        client_multi = Mock()
-        client_multi.name = "multi-bad"
-        client_multi.__str__ = Mock(return_value="multi-bad")
-        client_multi.is_saml_client.return_value = True
-        client_multi.is_system_client.return_value = False
+    def test_audit_function_multiple_bad_uris(self, auditor, create_mock_client):
+        client_multi = create_mock_client(name="multi-bad", is_saml_client=True)
         client_multi.get_resolved_redirect_uris.return_value = [
             "https://ok.com",
             "https://bad.com/*",

--- a/tests/auditors/client/test_saml_client_with_assertion_signature_disabled.py
+++ b/tests/auditors/client/test_saml_client_with_assertion_signature_disabled.py
@@ -40,33 +40,17 @@ class TestSamlClientWithAssertionSignatureDisabled:
         results = list(auditor.audit())
         assert len(results) == expected_findings
 
-    def test_audit_mixed_clients(self, auditor):
+    def test_audit_mixed_clients(self, auditor, create_mock_client):
         # 1. Secure SAML Client
-        client_secure = Mock()
-        client_secure.name = "secure-client"
-        client_secure.client_id = "secure-client-id"
-        client_secure.__str__ = Mock(return_value="secure-client")
-        client_secure.is_saml_client.return_value = True
+        client_secure = create_mock_client(name="secure-client", is_saml_client=True)
         client_secure.get_saml_assertion_signature.return_value = True
-        client_secure.is_system_client.return_value = False
 
         # 2. Vulnerable SAML Client
-        client_vuln = Mock()
-        client_vuln.name = "vuln-client"
-        client_vuln.client_id = "vuln-client-id"
-        client_vuln.__str__ = Mock(return_value="vuln-client")
-        client_vuln.is_saml_client.return_value = True
+        client_vuln = create_mock_client(name="vuln-client", is_saml_client=True)
         client_vuln.get_saml_assertion_signature.return_value = False
-        client_vuln.is_system_client.return_value = False
 
         # 3. OIDC Client
-        client_oidc = Mock()
-        client_oidc.name = "oidc-client"
-        client_oidc.client_id = "oidc-client-id"
-        client_oidc.__str__ = Mock(return_value="oidc-client")
-        client_oidc.is_saml_client.return_value = False
-        client_oidc.get_saml_assertion_signature.return_value = False
-        client_oidc.is_system_client.return_value = False
+        client_oidc = create_mock_client(name="oidc-client", is_saml_client=False)
 
         auditor._DB.get_all_clients.return_value = [client_secure, client_vuln, client_oidc]
 
@@ -74,4 +58,4 @@ class TestSamlClientWithAssertionSignatureDisabled:
 
         assert len(results) == 1
 
-        assert results[0]._offending_object.name == "vuln-client"
+        assert results[0]._offending_object.get_name() == "vuln-client"

--- a/tests/auditors/client/test_saml_client_with_client_signature_disabled.py
+++ b/tests/auditors/client/test_saml_client_with_client_signature_disabled.py
@@ -39,31 +39,18 @@ class TestSamlClientWithClientSignatureDisabled:
         results = list(auditor.audit())
         assert len(results) == 1
 
-    def test_audit_function_mixed_clients(self, auditor):
-        client_oidc = Mock()
-        client_oidc.name = "oidc-client"
-        client_oidc.__str__ = Mock(return_value="oidc-client")
-        client_oidc.is_saml_client.return_value = False
-        client_oidc.is_saml_client_signature_required.return_value = False
-        client_oidc.is_system_client.return_value = False
+    def test_audit_function_mixed_clients(self, auditor, create_mock_client):
+        client_oidc = create_mock_client(name="oidc-client", is_saml_client=False)
 
-        client_secure = Mock()
-        client_secure.name = "secure-saml"
-        client_secure.__str__ = Mock(return_value="secure-saml")
-        client_secure.is_saml_client.return_value = True
+        client_secure = create_mock_client(name="secure-saml", is_saml_client=True)
         client_secure.is_saml_client_signature_required.return_value = True
-        client_secure.is_system_client.return_value = False
 
-        client_vuln = Mock()
-        client_vuln.name = "vuln-saml"
-        client_vuln.__str__ = Mock(return_value="vuln-saml")
-        client_vuln.is_saml_client.return_value = True
+        client_vuln = create_mock_client(name="vuln-saml", is_saml_client=True)
         client_vuln.is_saml_client_signature_required.return_value = False
-        client_vuln.is_system_client.return_value = False
 
         auditor._DB.get_all_clients.return_value = [client_oidc, client_secure, client_vuln]
 
         results = list(auditor.audit())
 
         assert len(results) == 1
-        assert results[0]._offending_object.name == "vuln-saml"
+        assert results[0]._offending_object.get_name() == "vuln-saml"

--- a/tests/auditors/client/test_saml_client_with_encryption_disabled.py
+++ b/tests/auditors/client/test_saml_client_with_encryption_disabled.py
@@ -37,31 +37,18 @@ class TestSamlClientWithEncryptionDisabled:
         results = list(auditor.audit())
         assert len(results) == 1
 
-    def test_audit_mixed_clients(self, auditor):
-        client_secure = Mock()
-        client_secure.name = "secure-saml"
-        client_secure.__str__ = Mock(return_value="secure-saml")
-        client_secure.is_saml_client.return_value = True
+    def test_audit_mixed_clients(self, auditor, create_mock_client):
+        client_secure = create_mock_client(name="secure-saml", is_saml_client=True)
         client_secure.is_saml_encryption_enabled.return_value = True
-        client_secure.is_system_client.return_value = False
 
-        client_vuln = Mock()
-        client_vuln.name = "vuln-saml"
-        client_vuln.__str__ = Mock(return_value="vuln-saml")
-        client_vuln.is_saml_client.return_value = True
+        client_vuln = create_mock_client(name="vuln-saml", is_saml_client=True)
         client_vuln.is_saml_encryption_enabled.return_value = False
-        client_vuln.is_system_client.return_value = False
 
-        client_oidc = Mock()
-        client_oidc.name = "oidc-client"
-        client_oidc.__str__ = Mock(return_value="oidc-client")
-        client_oidc.is_saml_client.return_value = False
-        client_oidc.is_saml_encryption_enabled.return_value = False
-        client_oidc.is_system_client.return_value = False
+        client_oidc = create_mock_client(name="oidc-client", is_saml_client=False)
 
         auditor._DB.get_all_clients.return_value = [client_secure, client_vuln, client_oidc]
 
         results = list(auditor.audit())
 
         assert len(results) == 1
-        assert results[0]._offending_object.name == "vuln-saml"
+        assert results[0]._offending_object.get_name() == "vuln-saml"

--- a/tests/auditors/client/test_saml_client_with_weak_signature_algorithm.py
+++ b/tests/auditors/client/test_saml_client_with_weak_signature_algorithm.py
@@ -47,32 +47,19 @@ class TestSamlClientWithWeakSignatureAlgorithm:
         if expected_findings > 0:
             assert results[0].additional_details["detected_algorithm"] == algorithm
 
-    def test_audit_mixed_clients(self, auditor):
-        client_oidc = Mock()
-        client_oidc.name = "oidc"
-        client_oidc.__str__ = Mock(return_value="oidc")
-        client_oidc.is_saml_client.return_value = False
-        client_oidc.get_saml_signature_algorithm.return_value = "RSA_SHA1"
-        client_oidc.is_system_client.return_value = False
+    def test_audit_mixed_clients(self, auditor, create_mock_client):
+        client_oidc = create_mock_client(name="oidc", is_saml_client=False)
 
-        client_strong = Mock()
-        client_strong.name = "strong"
-        client_strong.__str__ = Mock(return_value="strong")
-        client_strong.is_saml_client.return_value = True
+        client_strong = create_mock_client(name="strong", is_saml_client=True)
         client_strong.get_saml_signature_algorithm.return_value = "RSA_SHA256"
-        client_strong.is_system_client.return_value = False
 
-        client_weak = Mock()
-        client_weak.name = "weak"
-        client_weak.__str__ = Mock(return_value="weak")
-        client_weak.is_saml_client.return_value = True
+        client_weak = create_mock_client(name="weak", is_saml_client=True)
         client_weak.get_saml_signature_algorithm.return_value = "RSA_SHA1"
-        client_weak.is_system_client.return_value = False
 
         auditor._DB.get_all_clients.return_value = [client_oidc, client_strong, client_weak]
 
         results = list(auditor.audit())
 
         assert len(results) == 1
-        assert results[0]._offending_object.name == "weak"
+        assert results[0]._offending_object.get_name() == "weak"
         assert results[0].additional_details["detected_algorithm"] == "RSA_SHA1"

--- a/tests/auditors/client/test_saml_client_without_onetimeuse_condition.py
+++ b/tests/auditors/client/test_saml_client_without_onetimeuse_condition.py
@@ -37,31 +37,18 @@ class TestSamlClientWithoutOneTimeUseCondition:
         results = list(auditor.audit())
         assert len(results) == 1
 
-    def test_audit_function_multiple_clients_mixed(self, auditor):
-        client_secure = Mock()
-        client_secure.name = "secure-saml"
-        client_secure.__str__ = Mock(return_value="secure-saml")
-        client_secure.is_saml_client.return_value = True
+    def test_audit_function_multiple_clients_mixed(self, auditor, create_mock_client):
+        client_secure = create_mock_client(name="secure-saml", is_saml_client=True)
         client_secure.is_saml_onetimeuse_condition_enabled.return_value = True
-        client_secure.is_system_client.return_value = False
 
-        client_vuln = Mock()
-        client_vuln.name = "vuln-saml"
-        client_vuln.__str__ = Mock(return_value="vuln-saml")
-        client_vuln.is_saml_client.return_value = True
+        client_vuln = create_mock_client(name="vuln-saml", is_saml_client=True)
         client_vuln.is_saml_onetimeuse_condition_enabled.return_value = False
-        client_vuln.is_system_client.return_value = False
 
-        client_oidc = Mock()
-        client_oidc.name = "oidc-client"
-        client_oidc.__str__ = Mock(return_value="oidc-client")
-        client_oidc.is_saml_client.return_value = False
-        client_oidc.is_saml_onetimeuse_condition_enabled.return_value = False
-        client_oidc.is_system_client.return_value = False
+        client_oidc = create_mock_client(name="oidc-client", is_saml_client=False)
 
         auditor._DB.get_all_clients.return_value = [client_secure, client_vuln, client_oidc]
 
         results = list(auditor.audit())
 
         assert len(results) == 1
-        assert results[0]._offending_object.name == "vuln-saml"
+        assert results[0]._offending_object.get_name() == "vuln-saml"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -164,23 +164,37 @@ def create_mock_scope():
 
 
 @pytest.fixture
-def mock_client(mock_realm):
-    client = unittest.mock.create_autospec(spec=Client, instance=True)
-    client.get_name.return_value = "mock-test-client"
-    client.is_enabled.return_value = True
-    client.get_realm.return_value = mock_realm
-    client.get_default_client_scopes.return_value = []
-    client.get_optional_client_scopes.return_value = []
-    client.is_oidc_client.return_value = True
-    client.is_system_client.return_value = False
-    client.is_default_keycloak_client.return_value = False
-    client.is_realm_specific_client.return_value = False
-    client.get_protocol_mappers.return_value = []
-    client.has_service_account_enabled.return_value = False
-    client.has_full_scope_allowed.return_value = False
-    client.get_directly_assigned_realm_roles.return_value = []
-    client.get_directly_assigned_client_roles.return_value = {}
-    return client
+def create_mock_client(mock_realm):
+    def _create_mock_client(
+        name="mock-test-client",
+        is_saml_client=False,
+        is_system_client=False,
+    ):
+        client = unittest.mock.create_autospec(spec=Client, instance=True)
+        client.get_name.return_value = name
+        client.__str__.return_value = name
+        client.is_enabled.return_value = True
+        client.get_realm.return_value = mock_realm
+        client.get_default_client_scopes.return_value = []
+        client.get_optional_client_scopes.return_value = []
+        client.is_oidc_client.return_value = not is_saml_client
+        client.is_saml_client.return_value = is_saml_client
+        client.is_system_client.return_value = is_system_client
+        client.is_default_keycloak_client.return_value = False
+        client.is_realm_specific_client.return_value = False
+        client.get_protocol_mappers.return_value = []
+        client.has_service_account_enabled.return_value = False
+        client.has_full_scope_allowed.return_value = False
+        client.get_directly_assigned_realm_roles.return_value = []
+        client.get_directly_assigned_client_roles.return_value = {}
+        return client
+
+    return _create_mock_client
+
+
+@pytest.fixture
+def mock_client(create_mock_client):
+    return create_mock_client()
 
 
 @pytest.fixture


### PR DESCRIPTION
Replace bare `Mock()` client constructions in SAML test cases with a new `create_mock_client` factory fixture in conftest.py, following the existing factory fixture pattern. The `mock_client` fixture now delegates to `create_mock_client()` for a single source of truth. The previous pattern led to some issues due to redundant code, which also made it harder to change the behavior of the `Client` class. For details of that issue, see #268.

**AI Disclosure**: This was an experiment in delegating the entire implementation to Deepseek v4 Pro via opencode, as an Alternative to Claude Code. The results were... mixed. It did well in creating the new fixture, but made some mistakes in the edits, which led to the removal of some inline comments that I wanted to maintain. It also broke some code while refactoring, fixed its own mistake, and then claimed it had fixed a mistake that was there before the refactoring. Finally, it did not make the connection that the `mock_client` should delegate to `create_mock_client` until I explicitly prompted it to make this change. In total, I would say that I probably still saved some time compared to doing this manually, but that likely says more about my level of familiarity with the refactoring tools in a good IDE than it says about opencode and Deepseek V4 Pro.