### PR TITLE
Add `admin-permissions` client to list of integrated clients

### DIFF
--- a/kcwarden/api/auditor.py
+++ b/kcwarden/api/auditor.py
@@ -118,7 +118,7 @@ class ClientAuditor(Auditor, ABC):
     """
 
     def should_consider_client(self, client: Client) -> bool:
-        return self.is_not_ignored(client) and not client.is_system_client()
+        return self.is_not_ignored(client) and not client.is_keycloak_internal_client()
 
     def audit(self):
         for client in self._DB.get_all_clients():

--- a/kcwarden/custom_types/keycloak_object.py
+++ b/kcwarden/custom_types/keycloak_object.py
@@ -571,10 +571,12 @@ class Client(Dataclass):
             self.get_realm().get_name() == "master" and self.get_name().endswith("-realm") and "protocol" not in self._d
         )
 
-    def is_system_client(self) -> bool:
-        # If "account" client does not exist, Keycloak can create a system client in the realm for certain internal operations
+    def is_keycloak_internal_client(self) -> bool:
+        # If the "account" client does not exist, Keycloak can create a system client in the realm for certain internal operations
         # See https://github.com/keycloak/keycloak/blob/main/server-spi-private/src/main/java/org/keycloak/models/utils/SystemClientUtil.java
-        return self.get_name() == "_system"
+        # If the admin-permissions feature is active, an "admin-permissions" client is automatically created.
+        # https://github.com/keycloak/keycloak/blob/4cd0616bc917014d73d712e059af2b026d84cfe8/services/src/main/java/org/keycloak/services/managers/RealmManager.java#L625-L633
+        return self.get_name() in ["_system", "admin-permissions"]
 
     def get_protocol(self) -> str:
         # Every client should have the "protocol" field set, but the "master-realm"
@@ -585,7 +587,7 @@ class Client(Dataclass):
         except KeyError:
             # If the client is a realm-specific or system client, it for some reason does not
             # have a "protocol" set. Return openid-connect anyway.
-            if self.is_realm_specific_client() or self.is_system_client():
+            if self.is_realm_specific_client() or self.is_keycloak_internal_client():
                 return "openid-connect"
             # This case should never happen, so instead of blindly returning something,
             # we'd like to know about it. Raise an exception.
@@ -622,7 +624,7 @@ class Client(Dataclass):
     def get_client_authenticator_type(self) -> str | None:
         if self.is_public():
             return None
-        if self.is_system_client():
+        if self.is_keycloak_internal_client():
             return None
         return self._d["clientAuthenticatorType"]
 

--- a/tests/api/test_client_auditor_should_consider_client.py
+++ b/tests/api/test_client_auditor_should_consider_client.py
@@ -24,17 +24,17 @@ class TestClientAuditorShouldConsiderClient:
         return auditor_instance
 
     def test_should_consider_normal_client(self, mock_client, auditor):
-        mock_client.is_system_client.return_value = False
+        mock_client.is_keycloak_internal_client.return_value = False
         assert auditor.should_consider_client(mock_client) is True
 
     def test_should_consider_system_client_returns_false(self, mock_client, auditor):
         # Keycloak internal _system client should always be skipped
-        mock_client.is_system_client.return_value = True
+        mock_client.is_keycloak_internal_client.return_value = True
         assert auditor.should_consider_client(mock_client) is False
 
     def test_should_consider_ignored_client_returns_false(self, mock_client, auditor):
         auditor.is_not_ignored.return_value = False
-        mock_client.is_system_client.return_value = False
+        mock_client.is_keycloak_internal_client.return_value = False
         assert auditor.should_consider_client(mock_client) is False
 
 

--- a/tests/auditors/client/test_client_access_token_lifespan_too_long.py
+++ b/tests/auditors/client/test_client_access_token_lifespan_too_long.py
@@ -95,32 +95,32 @@ class TestClientAccessTokenLifespanTooLong:
         client1.get_access_token_lifespan_override.return_value = None  # No override - OK
         client1.get_realm.return_value = mock_realm
         client1.is_oidc_client.return_value = True
-        client1.is_system_client.return_value = False
+        client1.is_keycloak_internal_client.return_value = False
 
         client2 = Mock()
         client2.get_access_token_lifespan_override.return_value = 300  # 5 minutes - OK
         client2.get_realm.return_value = mock_realm
         client2.is_oidc_client.return_value = True
-        client2.is_system_client.return_value = False
+        client2.is_keycloak_internal_client.return_value = False
 
         client3 = Mock()
         client3.get_access_token_lifespan_override.return_value = 1800  # 30 minutes - Too long
         client3.get_realm.return_value = mock_realm
         client3.is_oidc_client.return_value = True
-        client3.is_system_client.return_value = False
+        client3.is_keycloak_internal_client.return_value = False
 
         client4 = Mock()
         client4.get_access_token_lifespan_override.return_value = 900  # 15 minutes - Too long
         client4.get_realm.return_value = mock_realm
         client4.is_oidc_client.return_value = True
-        client4.is_system_client.return_value = False
+        client4.is_keycloak_internal_client.return_value = False
 
         # client5 is not an OIDC client - should be ignored
         client5 = Mock()
         client5.get_access_token_lifespan_override.return_value = 1800  # 30 minutes but ignored
         client5.get_realm.return_value = mock_realm
         client5.is_oidc_client.return_value = False
-        client5.is_system_client.return_value = False
+        client5.is_keycloak_internal_client.return_value = False
 
         auditor._DB.get_all_clients.return_value = [client1, client2, client3, client4, client5]
         results = list(auditor.audit())

--- a/tests/auditors/client/test_client_with_default_offline_access_scope.py
+++ b/tests/auditors/client/test_client_with_default_offline_access_scope.py
@@ -80,7 +80,7 @@ class TestClientWithDefaultOfflineAccessScope:
         client1.use_refresh_tokens.return_value = True
         client1.is_public.return_value = False
         client1.is_realm_specific_client.return_value = False
-        client1.is_system_client.return_value = False
+        client1.is_keycloak_internal_client.return_value = False
 
         client2 = Mock()
         client2.get_default_client_scopes.return_value = []
@@ -92,7 +92,7 @@ class TestClientWithDefaultOfflineAccessScope:
         client2.is_public.return_value = True
         client2.allows_user_authentication.return_value = True
         client2.is_realm_specific_client.return_value = False
-        client2.is_system_client.return_value = False
+        client2.is_keycloak_internal_client.return_value = False
 
         client3 = Mock()
         client3.get_default_client_scopes.return_value = ["offline_access"]
@@ -104,7 +104,7 @@ class TestClientWithDefaultOfflineAccessScope:
         client3.is_public.return_value = False
         client3.allows_user_authentication.return_value = True
         client3.is_realm_specific_client.return_value = False
-        client3.is_system_client.return_value = False
+        client3.is_keycloak_internal_client.return_value = False
 
         auditor._DB.get_all_clients.return_value = [client1, client2, client3]
         results = list(auditor.audit())

--- a/tests/auditors/client/test_client_with_full_scope_allowed.py
+++ b/tests/auditors/client/test_client_with_full_scope_allowed.py
@@ -59,21 +59,21 @@ class TestClientWithFullScopeAllowed:
         client1.get_default_client_scopes.return_value = ["email"]
         client1.get_optional_client_scopes.return_value = ["profile"]
         client1.is_realm_specific_client.return_value = False
-        client1.is_system_client.return_value = False
+        client1.is_keycloak_internal_client.return_value = False
 
         client2 = Mock()
         client2.has_full_scope_allowed.return_value = False
         client2.get_default_client_scopes.return_value = ["email", "profile"]
         client2.get_optional_client_scopes.return_value = ["address"]
         client2.is_realm_specific_client.return_value = False
-        client2.is_system_client.return_value = False
+        client2.is_keycloak_internal_client.return_value = False
 
         client3 = Mock()
         client3.has_full_scope_allowed.return_value = True
         client3.get_default_client_scopes.return_value = ["offline_access"]
         client3.get_optional_client_scopes.return_value = []
         client3.is_realm_specific_client.return_value = False
-        client3.is_system_client.return_value = False
+        client3.is_keycloak_internal_client.return_value = False
 
         auditor._DB.get_all_clients.return_value = [client1, client2, client3]
         results = list(auditor.audit())

--- a/tests/auditors/client/test_client_with_optional_offline_access_scope.py
+++ b/tests/auditors/client/test_client_with_optional_offline_access_scope.py
@@ -77,7 +77,7 @@ class TestClientWithOptionalOfflineAccessScope:
         client1.use_refresh_tokens.return_value = True
         client1.is_public.return_value = False
         client1.is_realm_specific_client.return_value = False
-        client1.is_system_client.return_value = False
+        client1.is_keycloak_internal_client.return_value = False
 
         client2 = Mock()
         client2.get_optional_client_scopes.return_value = []
@@ -88,7 +88,7 @@ class TestClientWithOptionalOfflineAccessScope:
         client2.use_refresh_tokens.return_value = False
         client2.is_public.return_value = True
         client2.is_realm_specific_client.return_value = False
-        client2.is_system_client.return_value = False
+        client2.is_keycloak_internal_client.return_value = False
 
         client3 = Mock()
         client3.get_optional_client_scopes.return_value = ["offline_access"]
@@ -99,7 +99,7 @@ class TestClientWithOptionalOfflineAccessScope:
         client3.use_refresh_tokens.return_value = True
         client3.is_public.return_value = False
         client3.is_realm_specific_client.return_value = False
-        client3.is_system_client.return_value = False
+        client3.is_keycloak_internal_client.return_value = False
 
         auditor._DB.get_all_clients.return_value = [client1, client2, client3]
         results = list(auditor.audit())

--- a/tests/auditors/client/test_client_with_service_account_and_other_flow_enabled.py
+++ b/tests/auditors/client/test_client_with_service_account_and_other_flow_enabled.py
@@ -91,7 +91,7 @@ class TestClientWithServiceAccountAndOtherFlowEnabled:
         client1.has_standard_flow_enabled.return_value = True
         client1.allows_user_authentication.return_value = True
         client1.is_realm_specific_client.return_value = False
-        client1.is_system_client.return_value = False
+        client1.is_keycloak_internal_client.return_value = False
 
         client2 = Mock()
         client2.is_oidc_client.return_value = True
@@ -103,7 +103,7 @@ class TestClientWithServiceAccountAndOtherFlowEnabled:
         client2.has_standard_flow_enabled.return_value = False
         client2.allows_user_authentication.return_value = False
         client2.is_realm_specific_client.return_value = False
-        client2.is_system_client.return_value = False
+        client2.is_keycloak_internal_client.return_value = False
 
         client3 = Mock()
         client3.is_oidc_client.return_value = True
@@ -115,7 +115,7 @@ class TestClientWithServiceAccountAndOtherFlowEnabled:
         client3.has_device_authorization_grant_flow_enabled.return_value = False
         client3.allows_user_authentication.return_value = True
         client3.is_realm_specific_client.return_value = False
-        client3.is_system_client.return_value = False
+        client3.is_keycloak_internal_client.return_value = False
 
         auditor._DB.get_all_clients.return_value = [client1, client2, client3]
         results = list(auditor.audit())

--- a/tests/auditors/client/test_using_nondefault_user_attributes_in_clients_without_user_profiles_feature_is_dangerous.py
+++ b/tests/auditors/client/test_using_nondefault_user_attributes_in_clients_without_user_profiles_feature_is_dangerous.py
@@ -103,7 +103,7 @@ class TestUsingNonDefaultUserAttributesInClientsWithoutUserProfilesFeatureIsDang
     def test_audit_function_multiple_clients(self, auditor):
         # Create separate mock clients with distinct settings
         client1 = Mock()
-        client1.is_system_client.return_value = False
+        client1.is_keycloak_internal_client.return_value = False
         realm1: Realm = Mock()
         realm1.get_unmanaged_attribute_policy.return_value = "ENABLED"
         client1.get_realm.return_value = realm1
@@ -113,7 +113,7 @@ class TestUsingNonDefaultUserAttributesInClientsWithoutUserProfilesFeatureIsDang
         client1.get_protocol_mappers.return_value = [mapper1]
 
         client2 = Mock()
-        client2.is_system_client.return_value = False
+        client2.is_keycloak_internal_client.return_value = False
         realm2 = Mock()
         realm2.get_unmanaged_attribute_policy.return_value = "ADMIN_EDIT"
         client2.get_realm.return_value = realm2

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -168,7 +168,7 @@ def create_mock_client(mock_realm):
     def _create_mock_client(
         name="mock-test-client",
         is_saml_client=False,
-        is_system_client=False,
+        is_keycloak_internal_client=False,
     ):
         client = unittest.mock.create_autospec(spec=Client, instance=True)
         client.get_name.return_value = name
@@ -179,7 +179,7 @@ def create_mock_client(mock_realm):
         client.get_optional_client_scopes.return_value = []
         client.is_oidc_client.return_value = not is_saml_client
         client.is_saml_client.return_value = is_saml_client
-        client.is_system_client.return_value = is_system_client
+        client.is_keycloak_internal_client.return_value = is_keycloak_internal_client
         client.is_default_keycloak_client.return_value = False
         client.is_realm_specific_client.return_value = False
         client.get_protocol_mappers.return_value = []

--- a/tests/custom_types/test_keycloak_object.py
+++ b/tests/custom_types/test_keycloak_object.py
@@ -30,10 +30,11 @@ class TestClient:
         ["client_id", "expected"],
         [
             ("_system", True),
+            ("admin-permissions", True),
             ("some-other-client", False),
         ],
     )
-    def test_is_system_client(self, client_id: str, expected: bool):
+    def test_is_keycloak_internal_client(self, client_id: str, expected: bool):
         client = Client(
             {
                 "clientId": client_id,
@@ -43,7 +44,7 @@ class TestClient:
             {},
             realm=Mock(),
         )
-        assert client.is_system_client() == expected
+        assert client.is_keycloak_internal_client() == expected
 
     def test_get_protocol_returns_openid_connect_for_system_client(self):
         client = Client(


### PR DESCRIPTION
The `admin-permissions` client is opportunistically created by Keycloak if the fine-grained admin permissions feature is activated. Is has the same issue as the `_system` client, in that it is not a complete object in the config dump. Thus, we handle it the same way. I also refactored the name of the method to make it match the new behavior. 

Fixes #286