### PR TITLE
Fix: Alert on service accounts with Full Scope Allowed

### DIFF
--- a/kcwarden/auditors/client/client_with_full_scope_allowed.py
+++ b/kcwarden/auditors/client/client_with_full_scope_allowed.py
@@ -6,15 +6,11 @@ from kcwarden.custom_types.result import Severity
 class ClientWithFullScopeAllowed(ClientAuditor):
     DEFAULT_SEVERITY = Severity.Info
     SHORT_DESCRIPTION = "Client has 'full scope allowed' set"
-    LONG_DESCRIPTION = "Keycloak scopes control what information and roles are added to an access token. Generally, access tokens should be 'least privilege', meaning that they only contain the roles and information that are actually required to achieve the task. If the 'Full scope allowed' option is set on a client, it ignores the configured scopes, and simply adds all roles that the user has to the token, as if all scopes were selected. This leads to overprivileged tokens."
+    LONG_DESCRIPTION = "Keycloak scopes control what information and roles are added to an access token. Generally, access tokens should be 'least privilege', meaning that they only contain the roles and information that are actually required to achieve the task. If the 'Full scope allowed' option is set on a client, it ignores the configured scopes, and simply adds all roles that the user or service account has to the token, as if all scopes were selected. This leads to overprivileged tokens."
     REFERENCE = ""
 
     def should_consider_client(self, client) -> bool:
-        return (
-            super().should_consider_client(client)
-            and client.allows_user_authentication()
-            and not client.is_realm_specific_client()
-        )
+        return super().should_consider_client(client) and not client.is_realm_specific_client()
 
     @staticmethod
     def client_has_full_scope_allowed(client) -> bool:

--- a/tests/auditors/client/test_client_with_full_scope_allowed.py
+++ b/tests/auditors/client/test_client_with_full_scope_allowed.py
@@ -12,14 +12,14 @@ class TestClientWithFullScopeAllowed:
         return auditor_instance
 
     @pytest.mark.parametrize(
-        "allows_user_auth, expected",
+        "is_realm_specific_client, expected",
         [
-            (True, True),  # User auth allowed
-            (False, False),  # User auth not allowed
+            (True, False),  # Realm-specific client
+            (False, True),  # other type of client
         ],
     )
-    def test_should_consider_client(self, mock_client, auditor, allows_user_auth, expected):
-        mock_client.allows_user_authentication.return_value = allows_user_auth
+    def test_should_consider_client(self, mock_client, auditor, is_realm_specific_client, expected):
+        mock_client.is_realm_specific_client.return_value = is_realm_specific_client
         assert auditor.should_consider_client(mock_client) == expected
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
Right now, our full scope allowed auditor only alerts on clients used for user authentication. However, it can also be relevant for service accounts. Thus, I have removed the relevant condition from the check.

Fixes #284.